### PR TITLE
177711219_change_schedule_for_stage

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -47,6 +47,15 @@ every 1.hour do
 end
 
 every 1.day do
-  ruby_script 'prune_database_tables.rb'
   ruby_script 'validators_update_avatar_url.rb'
+end
+
+if environment == 'production'
+  every 1.day, at: '1:00am' do
+    ruby_script 'prune_database_tables.rb'
+  end
+elsif environment == 'staging'
+  every 1.day, at: '1:00pm' do
+    ruby_script 'prune_database_tables.rb'
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -54,7 +54,7 @@ if environment == 'production'
   every 1.day, at: '1:00am' do
     ruby_script 'prune_database_tables.rb'
   end
-elsif environment == 'staging'
+elsif environment == 'stage'
   every 1.day, at: '1:00pm' do
     ruby_script 'prune_database_tables.rb'
   end


### PR DESCRIPTION
#### What's this PR do?
- Change schedule for prune_database_tables script

#### How should this be manually tested?
You can try it on your local machine, but please remember it will affect your crontab
- run `whenever --update-crontab --set environment=production` 
- `crontab -e`, last entry line should start with `0 1 * * *` and include `script/prune_database_tables.rb `
- then please run `whenever --update-crontab --set environment=stage` 
-  `crontab -e`, last entry line should start with `0 13 * * *`  and include `script/prune_database_tables.rb `
- to clear crontab run crontab -r

Also, 
- check `cap production deploy --dry-run`
- check  `cap stage deploy --dry-run`
You should see different `environment` values under `whenever:update_crontab` log entry in terminal

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/177711219

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
