### PR TITLE
178742429 count root and distance stats from last 2 days

### DIFF
--- a/app/logic/validator_score_v1_logic.rb
+++ b/app/logic/validator_score_v1_logic.rb
@@ -153,8 +153,8 @@ module ValidatorScoreV1Logic
       skipped_vote_all  = []
 
       p.payload[:validators].each do |v|
-        root_distance_all += v.validator_score_v1.root_distance_history
-        vote_distance_all += v.validator_score_v1.vote_distance_history
+        root_distance_all += v.validator_score_v1.root_distance_history.last(960)
+        vote_distance_all += v.validator_score_v1.vote_distance_history.last(960)
 
         # Get all the most recent skipped_votes
         skipped_vote_all.push v.validator_score_v1.skipped_vote_history[-1]


### PR DESCRIPTION
#### What's this PR do?
- Limits score records to last 2 days when counting root and distance stats

#### How should this be manually tested?
- Locally: run daemons. On staging: let it refresh the batch. Compare the difference on homepage in table header.

#### What are the relevant tickets?
- https://www.pivotaltracker.com/n/projects/2177859/stories/178742429

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
