### PR TITLE
178912445-fix-software-version-score

### DIFF
--- a/app/logic/validator_score_v1_logic.rb
+++ b/app/logic/validator_score_v1_logic.rb
@@ -341,7 +341,6 @@ module ValidatorScoreV1Logic
             validator.validator_score_v1.active_stake
         end
 
-        validator.validator_score_v1.assign_software_version_score
       rescue StandardError => e
         Appsignal.send_error(e)
       end
@@ -353,6 +352,11 @@ module ValidatorScoreV1Logic
       )
 
       p.payload[:this_batch].update(software_version: current_software_version)
+      
+      p.payload[:validators].each do |validator|
+        validator.validator_score_v1.assign_software_version_score(current_software_version)
+      end
+
 
       Pipeline.new(200, p.payload)
     rescue StandardError => e

--- a/app/models/validator_score_v1.rb
+++ b/app/models/validator_score_v1.rb
@@ -90,9 +90,9 @@ class ValidatorScoreV1 < ApplicationRecord
 
   def calculate_total_score
     # Assign special scores before calculating the total score
-    best_sw = Batch.last_scored(network)&.software_version
+    best_sv = Batch.last_scored(network)&.software_version
     assign_published_information_score
-    assign_software_version_score(best_sw)
+    assign_software_version_score(best_sv)
     assign_security_report_score
 
     self.total_score =
@@ -122,6 +122,7 @@ class ValidatorScoreV1 < ApplicationRecord
     end
 
     return unless ValidatorSoftwareVersion.valid_software_version?(software_version)
+
     version = ValidatorSoftwareVersion.new(
       number: software_version,
       network: validator.network,

--- a/app/services/validator_software_version.rb
+++ b/app/services/validator_software_version.rb
@@ -1,7 +1,11 @@
 class ValidatorSoftwareVersion < ::Gem::Version
-  def initialize(number:, network: 'mainnet')
+  def initialize(number:, network: 'mainnet', best_version: nil)
     super(number)
-    @current_version_number = network == 'mainnet' ? MAINNET_CLUSTER_VERSION : TESTNET_CLUSTER_VERSION
+    if best_version
+      @current_version_number = best_version
+    else
+      @current_version_number = network == 'mainnet' ? MAINNET_CLUSTER_VERSION : TESTNET_CLUSTER_VERSION
+    end
   end
 
   def running_latest_or_newer?
@@ -26,11 +30,6 @@ class ValidatorSoftwareVersion < ::Gem::Version
   end
 
   def self.valid_software_version?(number)
-    begin
-      self.new(number: number)
-      true
-    rescue
-      false
-    end
+    Gem::Version.correct? number
   end
 end

--- a/test/models/validator_score_v1_test.rb
+++ b/test/models/validator_score_v1_test.rb
@@ -54,14 +54,53 @@ class ValidatorScoreV1Test < ActiveSupport::TestCase
 
   test 'assign_software_version_score persists a software_version_score' do
     score = create(:validator_score_v1, software_version: '1.5.4')
-    score.assign_software_version_score
+    score.assign_software_version_score('1.5.6')
     assert(score.software_version_score.present?)
   end
 
   test 'assign_software_version_score preserves the existing value if junk is passed' do
     score = create(:validator_score_v1, software_version: 'foo', software_version_score: 1)
-    score.assign_software_version_score
+    score.assign_software_version_score(nil)
     assert_equal 1, score.reload.software_version_score
+  end
+
+  test 'assign_software_version_score scores 2 points for correct versions' do
+    current_version = '1.5.4'
+    create(:batch, software_version: '1.5.4')
+    score1 = create(:validator_score_v1, network: 'testnet', software_version: '1.5.4')
+    score2 = create(:validator_score_v1, network: 'testnet', software_version: '1.5.5')
+    score3 = create(:validator_score_v1, network: 'testnet', software_version: '1.6.4')
+
+    score1.assign_software_version_score(current_version)
+    score2.assign_software_version_score(current_version)
+    score3.assign_software_version_score(current_version)
+
+    assert_equal 2, score1.reload.software_version_score
+    assert_equal 2, score2.reload.software_version_score
+    assert_equal 2, score3.reload.software_version_score
+  end
+
+  test 'assign_software_version_score scores 1 points for correct versions' do
+    current_version = '1.5.4'
+    create(:batch, software_version: current_version)
+    score1 = create(:validator_score_v1, network: 'testnet', software_version: '1.5.3')
+    score2 = create(:validator_score_v1, network: 'testnet', software_version: '1.5.1')
+
+    score1.assign_software_version_score(current_version)
+    score2.assign_software_version_score(current_version)
+
+    assert_equal 1, score1.reload.software_version_score
+    assert_equal 1, score2.reload.software_version_score
+  end
+
+  test 'assign_software_version_score scores 0 points for correct versions' do
+    current_version = '1.5.4'
+    create(:batch, software_version: current_version)
+    score1 = create(:validator_score_v1, network: 'testnet', software_version: '1.4.4')
+
+    score1.assign_software_version_score(current_version)
+
+    assert_equal 0, score1.reload.software_version_score
   end
 
   test 'by_network_with_active_stake scope should return correct results' do


### PR DESCRIPTION
#### What's this PR do?
scores for validators software versions should be given correctly

#### How should this be manually tested?
while running scripts filter validators by specific versions and check if the scores are right:
 - if version is >= current_version (marked green on the bottom of homepage) - 2 pts
 - if version is < current_version, but only by minor - 1pts
 - if version is < current_version or nil - 0pts

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/178912445

#### Task completed checklist:
- [Y] Is there appropriate test coverage?
- [Y] Did I take into consideration possible security vulnerabilities?
- [Y] Are the controllers secure?
- [Y] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
