### PR TITLE
178998318_reduce_n_plus_1_queries_on_v_block_history_show

### DIFF
--- a/app/logic/validator_score_v1_logic.rb
+++ b/app/logic/validator_score_v1_logic.rb
@@ -267,6 +267,8 @@ module ValidatorScoreV1Logic
         Appsignal.send_error(e)
       end
 
+      p.payload[:this_batch].update(average_skipped_slot_percent: avg_skipped_slot_pct_all)
+
       Pipeline.new(
         200,
         p.payload.merge(

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -9,22 +9,23 @@
 #
 # Table name: batches
 #
-#  id                        :bigint           not null, primary key
-#  best_skipped_vote         :float(24)
-#  gathered_at               :datetime
-#  network                   :string(191)
-#  root_distance_all_average :float(24)
-#  root_distance_all_median  :integer
-#  scored_at                 :datetime
-#  skipped_slot_all_average  :float(24)
-#  skipped_slot_all_median   :float(24)
-#  skipped_vote_all_median   :float(24)
-#  software_version          :string(191)
-#  uuid                      :string(191)
-#  vote_distance_all_average :float(24)
-#  vote_distance_all_median  :integer
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
+#  id                           :bigint           not null, primary key
+#  average_skipped_slot_percent :float(24)
+#  best_skipped_vote            :float(24)
+#  gathered_at                  :datetime
+#  network                      :string(191)
+#  root_distance_all_average    :float(24)
+#  root_distance_all_median     :integer
+#  scored_at                    :datetime
+#  skipped_slot_all_average     :float(24)
+#  skipped_slot_all_median      :float(24)
+#  skipped_vote_all_median      :float(24)
+#  software_version             :string(191)
+#  uuid                         :string(191)
+#  vote_distance_all_average    :float(24)
+#  vote_distance_all_median     :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 # Indexes
 #

--- a/db/migrate/20210729100219_add_average_skipped_slot_percent_to_batches.rb
+++ b/db/migrate/20210729100219_add_average_skipped_slot_percent_to_batches.rb
@@ -1,0 +1,5 @@
+class AddAverageSkippedSlotPercentToBatches < ActiveRecord::Migration[6.1]
+  def change
+    add_column :batches, :average_skipped_slot_percent, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_25_174729) do
+ActiveRecord::Schema.define(version: 2021_07_29_100219) do
 
-  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "batches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "batches", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -47,13 +47,16 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.string "software_version"
     t.float "skipped_vote_all_median"
     t.float "best_skipped_vote"
+    t.float "skipped_slot_all_average"
+    t.float "skipped_slot_all_median"
+    t.float "average_skipped_slot_percent"
     t.index ["network", "created_at"], name: "index_batches_on_network_and_created_at"
     t.index ["network", "scored_at"], name: "index_batches_on_network_and_scored_at"
     t.index ["network", "uuid"], name: "index_batches_on_network_and_uuid"
     t.index ["network"], name: "index_batches_on_network"
   end
 
-  create_table "collectors", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "collectors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "payload_type"
     t.integer "payload_version"
@@ -64,7 +67,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["user_id"], name: "index_collectors_on_user_id"
   end
 
-  create_table "commission_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "commission_histories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "validator_id", null: false
     t.float "commission_before"
     t.float "commission_after"
@@ -79,7 +82,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["validator_id"], name: "index_commission_histories_on_validator_id"
   end
 
-  create_table "contact_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "contact_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name_encrypted"
     t.string "email_address_encrypted"
     t.string "telephone_encrypted"
@@ -92,7 +95,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "epoch_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "epoch_histories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "batch_uuid"
     t.integer "epoch"
     t.bigint "current_slot"
@@ -104,7 +107,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "batch_uuid"], name: "index_epoch_histories_on_network_and_batch_uuid"
   end
 
-  create_table "epoch_wall_clocks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "epoch_wall_clocks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "epoch"
     t.string "network"
     t.bigint "starting_slot"
@@ -115,7 +118,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "epoch"], name: "index_epoch_wall_clocks_on_network_and_epoch", unique: true
   end
 
-  create_table "ip_overrides", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ip_overrides", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "address"
     t.integer "traits_autonomous_system_number"
     t.string "country_iso_code"
@@ -129,7 +132,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["address"], name: "index_ip_overrides_on_address", unique: true
   end
 
-  create_table "ips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ips", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "address"
     t.string "continent_code"
     t.integer "continent_geoname_id"
@@ -175,7 +178,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["data_center_key"], name: "index_ips_on_data_center_key"
   end
 
-  create_table "ping_time_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ping_time_stats", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "batch_uuid"
     t.decimal "overall_min_time", precision: 10, scale: 3
     t.decimal "overall_max_time", precision: 10, scale: 3
@@ -187,7 +190,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "batch_uuid"], name: "index_ping_time_stats_on_network_and_batch_uuid"
   end
 
-  create_table "ping_times", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ping_times", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "batch_uuid"
     t.string "network"
     t.string "from_account"
@@ -212,7 +215,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "to_ip", "from_ip", "created_at"], name: "index_ping_times_on_network_and_to_ip_and_from_ip_and_created_at"
   end
 
-  create_table "reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "network"
     t.string "name"
     t.text "payload", size: :long
@@ -223,7 +226,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "name", "created_at"], name: "index_reports_on_network_and_name_and_created_at"
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "username", null: false
     t.string "encrypted_password", null: false
     t.string "reset_password_token"
@@ -255,7 +258,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "validator_block_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validator_block_histories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "validator_id", null: false
     t.integer "epoch"
     t.integer "leader_slots"
@@ -275,7 +278,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["validator_id"], name: "index_validator_block_histories_on_validator_id"
   end
 
-  create_table "validator_block_history_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validator_block_history_stats", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "batch_uuid"
     t.integer "epoch", unsigned: true
     t.bigint "start_slot", unsigned: true
@@ -290,7 +293,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "batch_uuid"], name: "index_validator_block_history_stats_on_network_and_batch_uuid"
   end
 
-  create_table "validator_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validator_histories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "network"
     t.string "batch_uuid"
     t.string "account"
@@ -316,7 +319,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "batch_uuid"], name: "index_validator_histories_on_network_and_batch_uuid"
   end
 
-  create_table "validator_ips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validator_ips", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "validator_id", null: false
     t.integer "version", default: 4
     t.string "address"
@@ -326,7 +329,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["validator_id"], name: "index_validator_ips_on_validator_id"
   end
 
-  create_table "validator_score_v1s", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validator_score_v1s", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "validator_id"
     t.integer "total_score"
     t.text "root_distance_history"
@@ -362,7 +365,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["validator_id"], name: "index_validator_score_v1s_on_validator_id"
   end
 
-  create_table "validators", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "validators", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "network"
     t.string "account"
     t.string "name"
@@ -379,7 +382,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["network", "account"], name: "index_validators_on_network_and_account", unique: true
   end
 
-  create_table "vote_account_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "vote_account_histories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "vote_account_id", null: false
     t.integer "commission"
     t.bigint "last_vote"
@@ -399,7 +402,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_174729) do
     t.index ["vote_account_id"], name: "index_vote_account_histories_on_vote_account_id"
   end
 
-  create_table "vote_accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "vote_accounts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "validator_id", null: false
     t.string "account"
     t.datetime "created_at", precision: 6, null: false

--- a/script/fill_average_skipped_slot_percent_in_batches.rb
+++ b/script/fill_average_skipped_slot_percent_in_batches.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# RAILS_ENV=production bundle exec ruby script/back_fill_validator_histories.rb
+
+require_relative '../config/environment'
+log_path = File.join(Rails.root, 'log', 'fill_average_skipped_slot_percent_in_batches.txt')
+logger = Logger.new(log_path)
+
+Batch.find_each do |batch|
+  batch_uuid = batch.uuid
+  network = batch.network
+
+  vbh = ValidatorBlockHistory.where(network: network, batch_uuid: batch_uuid)
+  vbhq = ValidatorBlockHistoryQuery.new(network, batch_uuid)
+  average = vbhq.average_skipped_slot_percent
+
+  if batch.update(average_skipped_slot_percent: average)
+    puts "Batch with uuid #{batch_uuid} from #{network} updated with average: #{average}.\n"
+  end
+  
+  rescue StandardError => e
+    logger.error "Batch id: #{batch.id}, message: #{e.message}\n#{e.backtrace}"
+    sleep(1)
+  # Go slow since this is just a 1-time backfill
+end

--- a/test/logic/validator_score_v1_logic_test.rb
+++ b/test/logic/validator_score_v1_logic_test.rb
@@ -294,6 +294,8 @@ class ValidatorScoreV1LogicTest < ActiveSupport::TestCase
     assert_nil p.payload[:validators][3]
                          .validator_score_v1
                          .skipped_slot_moving_average_history
+
+    assert_equal 0.4667, p.payload[:this_batch].average_skipped_slot_percent
   end
 
   test 'assign_block_history_score' do


### PR DESCRIPTION
#### What's this PR do?
- reduce n plus 1 queries on v block history show
- backfill averages for batch

#### How should this be manually tested?
- Part 1/2
- Run migration
- Run script `rails r script/fill_average_skipped_slot_percent_in_batches.rb`
- Check if batches gained new values

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/178998318

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
