### PR TITLE
178998318_add_average_to_batches_controller_changes_2

### DIFF
--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -93,18 +93,18 @@ class ValidatorsController < ApplicationController
       end.compact
 
       @validator.validator_block_histories
+                .includes(:batch)
                 .order('id desc')
                 .limit(@history_limit)
                 .reverse
                 .each do |vbh|
 
         i += 1
-        batch_stats = ValidatorBlockHistoryQuery.new(params[:network], vbh.batch_uuid)
 
         @data[i] = {
           skipped_slot_percent: vbh.skipped_slot_percent.to_f * 100.0,
           skipped_slot_percent_moving_average: vbh.skipped_slot_percent_moving_average.to_f * 100.0,
-          cluster_skipped_slot_percent_moving_average: batch_stats.average_skipped_slot_percent * 100
+          cluster_skipped_slot_percent_moving_average: vbh.batch.skipped_slot_all_average * 100
         }
       end
     end

--- a/app/models/validator_block_history.rb
+++ b/app/models/validator_block_history.rb
@@ -35,6 +35,7 @@ class ValidatorBlockHistory < ApplicationRecord
   include PipelineLogic
 
   belongs_to :validator
+  has_one :batch, primary_key: :batch_uuid, foreign_key: :uuid
 
   after_create :set_skipped_slot_percent_moving_average
 

--- a/test/models/validator_block_history_test.rb
+++ b/test/models/validator_block_history_test.rb
@@ -61,4 +61,13 @@ class ValidatorBlockHistoryTest < ActiveSupport::TestCase
     assert_equal(0.25, vbh3.skipped_slot_percent_moving_average)
     assert_equal(0.375, vbh4.skipped_slot_percent_moving_average)
   end
+
+  test 'has_one batch relationship works correctly' do
+    batch = create(:batch)
+    vbhs = create_list(:validator_block_history, 3, batch_uuid: batch.uuid)
+
+    vbhs.each do |vbh|
+      assert_equal batch, vbh.batch
+    end
+  end 
 end


### PR DESCRIPTION
#### What's this PR do?
- Add relationship between batch and validator_block_history
- Change way of getting data for average

#### How should this be manually tested?
- Part 2/2, first merge and run script from https://github.com/brianlong/www.validators.app/pull/182
- Open show page for any validator
- check Skipped Slot History table (best way to check it is to run first master, see the table, then switch to this branch and check if the results has not been changed)

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/178998318

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
