### PR TITLE
179166834_undefined_method_skipped_slot_average

### DIFF
--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -94,7 +94,7 @@ class ValidatorsController < ApplicationController
 
       i += 1
 
-      # Sometimes there is no batch yet for the vbh.
+      # We want to skip if there is no batch yet for the vbh.
       skipped_slot_all_average = vbh.batch&.skipped_slot_all_average
       next unless skipped_slot_all_average
 

--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -84,6 +84,7 @@ class ValidatorsController < ApplicationController
     # Grab the distances to show on the chart
     @vote_blocks = @val_histories.map(&:vote_distance).compact
 
+
     @validator.validator_block_histories
               .includes(:batch)
               .order('id desc')
@@ -93,10 +94,14 @@ class ValidatorsController < ApplicationController
 
       i += 1
 
+      # Sometimes there is no batch yet for the vbh.
+      skipped_slot_all_average = vbh.batch&.skipped_slot_all_average
+      next unless skipped_slot_all_average
+
       @data[i] = {
         skipped_slot_percent: vbh.skipped_slot_percent.to_f * 100.0,
         skipped_slot_percent_moving_average: vbh.skipped_slot_percent_moving_average.to_f * 100.0,
-        cluster_skipped_slot_percent_moving_average: vbh.batch.skipped_slot_all_average * 100
+        cluster_skipped_slot_percent_moving_average: skipped_slot_all_average * 100
       }
     end
     # flash[:error] = 'Due to a problem with our RPC server pool, the Skipped Slot % data is inaccurate. I am aware of the problem and working on a better solution. Thanks, Brian Long'


### PR DESCRIPTION
#### What's this PR do?
- Use safe operator when looking for skipped_slot_all_average + going to next record when result is nil

#### How should this be manually tested?
- Choose one of the validator
- Remove batch connected with one of the validator_block_history
- Remove limit from line 91 from validators_controller
- Open browser on show view for this validator
- Check if the charts are unchanged

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/179166834

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
