### PR TITLE
179475514 flag for absent validators in api

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -57,9 +57,8 @@ module Api
 
         if !params[:show_absent].nil? && \
           (params[:show_absent].in?([false, "false"]))
-          puts 'do not show absent'
-          vhs = ValidatorHistory.where(network: params[:network]).pluck(:account).uniq
-          @validators = @validators.where('validators.account IN (?)', vhs)
+          vhs = ValidatorHistory.where(network: params[:network]).distinct.pluck(:account)
+          @validators = @validators.where('account IN (?)', vhs)
         end
 
         @skipped_slots_report = Report.where(

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -55,6 +55,11 @@ module Api
           @validators = ValidatorSearchQuery.new(@validators).search(params[:q])
         end
 
+        if !params[:show_absent].nil? && \
+          (params[:show_absent].in?([false, "false"]))
+          @validators = @validators.where.not('validator_histories.epoch_credits': nil)
+        end
+
         @skipped_slots_report = Report.where(
           network: params[:network],
           name: 'build_skipped_slot_percent'

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -57,7 +57,9 @@ module Api
 
         if !params[:show_absent].nil? && \
           (params[:show_absent].in?([false, "false"]))
-          @validators = @validators.where.not('validator_histories.epoch_credits': nil)
+          puts 'do not show absent'
+          vhs = ValidatorHistory.where(network: params[:network]).pluck(:account).uniq
+          @validators = @validators.where('validators.account IN (?)', vhs)
         end
 
         @skipped_slots_report = Report.where(

--- a/app/views/public/api_documentation.html.erb
+++ b/app/views/public/api_documentation.html.erb
@@ -61,6 +61,8 @@
     <pre>curl -H "Token: secret-api-token" 'https://www.validators.app/api/v1/validators/:network.json?order=score&page=1&limit=50'</pre>
     <p>`q=query` will limit the results to entries containing query. The query value is compared against validator's name, account and score data center key.</p>
     <pre>curl -H "Token: secret-api-token" 'https://www.validators.app/api/v1/validators/:network.json?order=score&q=query'</pre>
+    <p>`show_absent=true|false` if set to false will limit the results to validators that have been active in last 30 days</p>
+    <pre>curl -H "Token: secret-api-token" 'https://www.validators.app/api/v1/validators/:network.json?show_absent=true'</pre>
     <p>Response:</p>
     <p>An Array of validators.</p>
     <pre>

--- a/test/controllers/api/v1/api_controller_test.rb
+++ b/test/controllers/api/v1/api_controller_test.rb
@@ -158,6 +158,36 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
   end
 
+  test 'GET api_v1_validators with token and false show_absent flag returns correct data' do
+    validator = create(:validator, :with_score, account: 'Test Account')
+    create(:vote_account, validator: validator)
+    create(:report, :build_skipped_slot_percent)
+    create(:ip, address: validator.score.ip_address)
+
+    get api_v1_validators_url(network: 'testnet', show_absent: false),
+        headers: { 'Token' => @user.api_token }
+
+    assert_response 200
+    json = response_to_json(@response.body)
+
+    assert_equal 0, json.size
+  end
+
+  test 'GET api_v1_validators with token and true show_absent flag returns correct data' do
+    validator = create(:validator, :with_score, account: 'Test Account')
+    create(:vote_account, validator: validator)
+    create(:report, :build_skipped_slot_percent)
+    create(:ip, address: validator.score.ip_address)
+
+    get api_v1_validators_url(network: 'testnet', show_absent: true),
+        headers: { 'Token' => @user.api_token }
+
+    assert_response 200
+    json = response_to_json(@response.body)
+
+    assert_equal 1, json.size
+  end
+
   test 'GET api_v1_validators with token and search query returns correct data' do
     validator = create(:validator, :with_score, account: 'Test Account')
 


### PR DESCRIPTION
#### What's this PR do?
add a bolean parameter to validators list api endpoint to exclude validators that are no longer returned by solana cli

#### How should this be manually tested?
- run tests
- check if api endpoint works as expected (/api/v1/validators/testnet?show_absent=false)
- (you can remove validator_history for a validator, after that it should not be seen if show_absent attribute is set to false)

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/179475514

#### Task completed checklist:
- [Y] Is there appropriate test coverage?
- [Y] Did I take into consideration possible security vulnerabilities?
- [Y] Are the controllers secure?
- [Y] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
