### PR TITLE
179932641 delinquent validators excluded from asn score

### DIFF
--- a/app/logic/asn_logic.rb
+++ b/app/logic/asn_logic.rb
@@ -60,7 +60,8 @@ module AsnLogic
 
         scores = p.payload[:scores].select do |score|
           score.data_center_key.in?(asn_stat.data_centers) && \
-            score.validator.scorable?
+            score.validator.scorable? && score.validator.is_active? && \
+            !score.validator.private_validator?
         end
 
         score_sum = 0

--- a/test/logic/asn_logic_test.rb
+++ b/test/logic/asn_logic_test.rb
@@ -9,11 +9,11 @@ class AsnLogicTest < ActiveSupport::TestCase
     ValidatorScoreV1.delete_all
 
     @ip = create(:ip, :ip_berlin) # asn: 54321
-    val = create(:validator, network: 'testnet')
+    @val = create(:validator, network: 'testnet')
 
     @score = create(
       :validator_score_v1,
-      validator: val,
+      validator: @val,
       network: 'testnet',
       vote_distance_history: [1, 2, 3],
       ip_address: @ip.address,
@@ -74,7 +74,7 @@ class AsnLogicTest < ActiveSupport::TestCase
   end
 
   test "calculate_and_save_stats does not calc delinquent validator" do
-    @score.update(delinquent: true)
+    @val.update(is_active: false)
 
     p = Pipeline.new(200, @payload)
                 .then(&gather_asns)


### PR DESCRIPTION
#### What's this PR do?
inactive and private validators does not count to the asn score

#### How should this be manually tested?
 - with ips in db, run dev/asn_logic_demo.rb on master branch and check the asn speedometers. 
    ten move to this branch and run demo again. Speedometers should be slightly better.
 - run tests

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/179932641

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
