### PR TITLE
180047388-tweak-cluster-stats-page

### DIFF
--- a/app/views/cluster_stats/_root_distance.html.erb
+++ b/app/views/cluster_stats/_root_distance.html.erb
@@ -1,33 +1,31 @@
-<div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Root Distance</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5 my-auto">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-purple">
-              <%= @stats[:root_distance][:median].to_i %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-purple">
-              <%= number_to_human(@stats[:root_distance][:average].to_f.round(1),
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted">
-              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
-              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
-            </div>
-            <div class="stat-title-2 text-purple">
-              <%= @stats[:root_distance][:min].to_i %> &ndash;
-              <%= number_to_human(@stats[:root_distance][:max].to_i,
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
+<div class="card">
+  <div class="card-content">
+    <h3 class="card-heading mb-4">Root Distance</h3>
+    <div class="row px-3 px-xl-5 mb-md-2">
+      <div class="stat col-5 my-auto">
+        <small class="text-muted">Median:</small>
+        <div class="h5 text-purple">
+          <%= @stats[:root_distance][:median].to_i %>
+        </div>
+        <small class="text-muted">Average:</small>
+        <div class="h5 text-purple">
+          <%= number_to_human(@stats[:root_distance][:average].to_f.round(1),
+                              format:'%n%u',
+                              units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+        </div>
+      </div>
+      <div class="stat col-7 my-auto px-0">
+        <div class="text-muted">
+          <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
+          <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
+        </div>
+        <div class="stat-title-2 text-purple">
+          <%= @stats[:root_distance][:min].to_i %> &ndash;
+          <%= number_to_human(@stats[:root_distance][:max].to_i,
+                              format:'%n%u',
+                              units: { thousand: 'K', million: 'M', billion: 'B' }) %>
         </div>
       </div>
     </div>
   </div>
+</div>

--- a/app/views/cluster_stats/_root_distance.html.erb
+++ b/app/views/cluster_stats/_root_distance.html.erb
@@ -1,0 +1,33 @@
+<div class="col-12 col-md-6 mb-4">
+    <div class="card">
+      <div class="card-content">
+        <h3 class="card-heading mb-4">Root Distance</h3>
+        <div class="row px-3 px-xl-5 mb-md-2">
+          <div class="stat col-5 my-auto">
+            <small class="text-muted">Median:</small>
+            <div class="h5 text-purple">
+              <%= @stats[:root_distance][:median].to_i %>
+            </div>
+            <small class="text-muted">Average:</small>
+            <div class="h5 text-purple">
+              <%= number_to_human(@stats[:root_distance][:average].to_f.round(1),
+                                  format:'%n%u',
+                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+            </div>
+          </div>
+          <div class="stat col-7 my-auto px-0">
+            <div class="text-muted">
+              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
+              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
+            </div>
+            <div class="stat-title-2 text-purple">
+              <%= @stats[:root_distance][:min].to_i %> &ndash;
+              <%= number_to_human(@stats[:root_distance][:max].to_i,
+                                  format:'%n%u',
+                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/cluster_stats/_skipped_slot.html.erb
+++ b/app/views/cluster_stats/_skipped_slot.html.erb
@@ -1,0 +1,31 @@
+<div class="col-12 col-md-6 mb-4">
+  <div class="card">
+    <div class="card-content">
+      <h3 class="card-heading mb-4">Skipped Slot&nbsp;&percnt;</h3>
+      <div class="row px-3 px-xl-5 mb-md-2">
+        <div class="stat col-5 my-auto">
+          <small class="text-muted">Median:</small>
+          <div class="h5 text-success">
+            <%= number_to_percentage @stats[:skipped_slots][:median].to_f * 100, precision: 1 %>
+          </div>
+          <small class="text-muted">Average:</small>
+          <div class="h5 text-success">
+            <%= number_to_percentage @stats[:skipped_slots][:average].to_f * 100, precision: 1 %>
+          </div>
+        </div>
+        <div class="stat col-7 my-auto px-0">
+          <div class="text-muted">
+            <i class="fas fa-long-arrow-alt-down text-success"></i>Min &ndash;
+            <i class="fas fa-long-arrow-alt-up text-success"></i>Max:
+          </div>
+          <h2 class="stat-title-2 text-success mt-2">
+            <% skipped_slots_min = @stats[:skipped_slots][:min].to_f * 100%>
+            <%= skipped_slots_min > 0 ? skipped_slots_min : 0 %>
+            &ndash; 
+            <%= @stats[:skipped_slots][:max].to_f * 100 %>
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/cluster_stats/_skipped_slot.html.erb
+++ b/app/views/cluster_stats/_skipped_slot.html.erb
@@ -1,30 +1,28 @@
-<div class="col-12 col-md-6 mb-4">
-  <div class="card">
-    <div class="card-content">
-      <h3 class="card-heading mb-4">Skipped Slot&nbsp;&percnt;</h3>
-      <div class="row px-3 px-xl-5 mb-md-2">
-        <div class="stat col-5 my-auto">
-          <small class="text-muted">Median:</small>
-          <div class="h5 text-success">
-            <%= number_to_percentage @stats[:skipped_slots][:median].to_f * 100, precision: 1 %>
-          </div>
-          <small class="text-muted">Average:</small>
-          <div class="h5 text-success">
-            <%= number_to_percentage @stats[:skipped_slots][:average].to_f * 100, precision: 1 %>
-          </div>
+<div class="card">
+  <div class="card-content">
+    <h3 class="card-heading mb-4">Skipped Slot&nbsp;&percnt;</h3>
+    <div class="row px-3 px-xl-5 mb-md-2">
+      <div class="stat col-5 my-auto">
+        <small class="text-muted">Median:</small>
+        <div class="h5 text-success">
+          <%= number_to_percentage @stats[:skipped_slots][:median].to_f * 100, precision: 1 %>
         </div>
-        <div class="stat col-7 my-auto px-0">
-          <div class="text-muted">
-            <i class="fas fa-long-arrow-alt-down text-success"></i>Min &ndash;
-            <i class="fas fa-long-arrow-alt-up text-success"></i>Max:
-          </div>
-          <h2 class="stat-title-2 text-success mt-2">
-            <% skipped_slots_min = @stats[:skipped_slots][:min].to_f * 100%>
-            <%= skipped_slots_min > 0 ? skipped_slots_min : 0 %>
-            &ndash; 
-            <%= @stats[:skipped_slots][:max].to_f * 100 %>
-          </h2>
+        <small class="text-muted">Average:</small>
+        <div class="h5 text-success">
+          <%= number_to_percentage @stats[:skipped_slots][:average].to_f * 100, precision: 1 %>
         </div>
+      </div>
+      <div class="stat col-7 my-auto px-0">
+        <div class="text-muted">
+          <i class="fas fa-long-arrow-alt-down text-success"></i>Min &ndash;
+          <i class="fas fa-long-arrow-alt-up text-success"></i>Max:
+        </div>
+        <h2 class="stat-title-2 text-success mt-2">
+          <% skipped_slots_min = @stats[:skipped_slots][:min].to_f * 100%>
+          <%= skipped_slots_min > 0 ? skipped_slots_min : 0 %>
+          &ndash; 
+          <%= @stats[:skipped_slots][:max].to_f * 100 %>
+        </h2>
       </div>
     </div>
   </div>

--- a/app/views/cluster_stats/_skipped_vote.html.erb
+++ b/app/views/cluster_stats/_skipped_vote.html.erb
@@ -1,23 +1,21 @@
-<div class="col-12 col-md-6 mb-4">
-  <div class="card">
-    <div class="card-content">
-      <h3 class="card-heading mb-4">Skipped Vote&nbsp;&percnt;</h3>
-      <div class="row px-3 px-xl-5 mb-md-2">
-        <div class="stat col-5">
-          <small class="text-muted">Median:</small>
-          <div class="h5 text-success">
-            <%= number_to_percentage @stats[:skipped_votes_percent][:median].to_f*100, precision: 1 %>
-          </div>
-          <small class="text-muted">Average:</small>
-          <div class="h5 text-success">
-            <%= number_to_percentage @stats[:skipped_votes_percent][:average].to_f*100, precision: 1 %>
-          </div>
+<div class="card">
+  <div class="card-content">
+    <h3 class="card-heading mb-4">Skipped Vote&nbsp;&percnt;</h3>
+    <div class="row px-3 px-xl-5 mb-md-2">
+      <div class="stat col-5">
+        <small class="text-muted">Median:</small>
+        <div class="h5 text-success">
+          <%= number_to_percentage @stats[:skipped_votes_percent][:median].to_f*100, precision: 1 %>
         </div>
-        <div class="stat col-7 my-auto px-0">
-          <div class="text-muted"><i class="fas fa-trophy text-success"></i>Best:</div>
-          <div class="stat-title-1 text-success">
-            <%= number_to_percentage @stats[:skipped_votes_percent][:best].to_f*100, precision: 2 %>
-          </div>
+        <small class="text-muted">Average:</small>
+        <div class="h5 text-success">
+          <%= number_to_percentage @stats[:skipped_votes_percent][:average].to_f*100, precision: 1 %>
+        </div>
+      </div>
+      <div class="stat col-7 my-auto px-0">
+        <div class="text-muted"><i class="fas fa-trophy text-success"></i>Best:</div>
+        <div class="stat-title-1 text-success">
+          <%= number_to_percentage @stats[:skipped_votes_percent][:best].to_f*100, precision: 2 %>
         </div>
       </div>
     </div>

--- a/app/views/cluster_stats/_skipped_vote.html.erb
+++ b/app/views/cluster_stats/_skipped_vote.html.erb
@@ -1,0 +1,25 @@
+<div class="col-12 col-md-6 mb-4">
+  <div class="card">
+    <div class="card-content">
+      <h3 class="card-heading mb-4">Skipped Vote&nbsp;&percnt;</h3>
+      <div class="row px-3 px-xl-5 mb-md-2">
+        <div class="stat col-5">
+          <small class="text-muted">Median:</small>
+          <div class="h5 text-success">
+            <%= number_to_percentage @stats[:skipped_votes_percent][:median].to_f*100, precision: 1 %>
+          </div>
+          <small class="text-muted">Average:</small>
+          <div class="h5 text-success">
+            <%= number_to_percentage @stats[:skipped_votes_percent][:average].to_f*100, precision: 1 %>
+          </div>
+        </div>
+        <div class="stat col-7 my-auto px-0">
+          <div class="text-muted"><i class="fas fa-trophy text-success"></i>Best:</div>
+          <div class="stat-title-1 text-success">
+            <%= number_to_percentage @stats[:skipped_votes_percent][:best].to_f*100, precision: 2 %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/cluster_stats/_vote_distance.html.erb
+++ b/app/views/cluster_stats/_vote_distance.html.erb
@@ -1,0 +1,34 @@
+<div class="col-12 col-md-6 mb-4">
+    <div class="card">
+      <div class="card-content">
+        <h3 class="card-heading mb-4">Vote Distance</h3>
+        <div class="row px-3 px-xl-5 mb-md-2">
+          <div class="stat col-5 my-auto">
+            <small class="text-muted">Median:</small>
+            <div class="h5 text-purple">
+              <%= @stats[:vote_distance][:median].to_i %>
+            </div>
+            <small class="text-muted">Average:</small>
+            <div class="h5 text-purple">
+              <%= number_to_human(@stats[:vote_distance][:average].to_f.round(1),
+                                  format:'%n%u',
+                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+            </div>
+          </div>
+          <div class="stat col-7 my-auto px-0">
+            <div class="text-muted">
+              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
+              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
+            </div>
+            <div class="stat-title-2 text-purple">
+              <%= @stats[:vote_distance][:min].to_i %> &ndash;
+              <%= number_to_human(@stats[:vote_distance][:max].to_i,
+                                  format:'%n%u',
+                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/cluster_stats/_vote_distance.html.erb
+++ b/app/views/cluster_stats/_vote_distance.html.erb
@@ -1,32 +1,29 @@
-<div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Vote Distance</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5 my-auto">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-purple">
-              <%= @stats[:vote_distance][:median].to_i %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-purple">
-              <%= number_to_human(@stats[:vote_distance][:average].to_f.round(1),
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted">
-              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
-              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
-            </div>
-            <div class="stat-title-2 text-purple">
-              <%= @stats[:vote_distance][:min].to_i %> &ndash;
-              <%= number_to_human(@stats[:vote_distance][:max].to_i,
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
+<div class="card">
+  <div class="card-content">
+    <h3 class="card-heading mb-4">Vote Distance</h3>
+    <div class="row px-3 px-xl-5 mb-md-2">
+      <div class="stat col-5 my-auto">
+        <small class="text-muted">Median:</small>
+        <div class="h5 text-purple">
+          <%= @stats[:vote_distance][:median].to_i %>
+        </div>
+        <small class="text-muted">Average:</small>
+        <div class="h5 text-purple">
+          <%= number_to_human(@stats[:vote_distance][:average].to_f.round(1),
+                              format:'%n%u',
+                              units: { thousand: 'K', million: 'M', billion: 'B' }) %>
+        </div>
+      </div>
+      <div class="stat col-7 my-auto px-0">
+        <div class="text-muted">
+          <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
+          <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
+        </div>
+        <div class="stat-title-2 text-purple">
+          <%= @stats[:vote_distance][:min].to_i %> &ndash;
+          <%= number_to_human(@stats[:vote_distance][:max].to_i,
+                              format:'%n%u',
+                              units: { thousand: 'K', million: 'M', billion: 'B' }) %>
         </div>
       </div>
     </div>

--- a/app/views/cluster_stats/index.html.erb
+++ b/app/views/cluster_stats/index.html.erb
@@ -4,11 +4,20 @@
             class: 'btn btn-sm btn-secondary mb-3' %>
 
 <div class="row">
-  <%= render partial: "root_distance" %>
-  <%= render partial: "vote_distance" %>
+  <div class="col-12 col-md-6 mb-4">
+    <%= render partial: "root_distance" %>
+  </div>
+  <div class="col-12 col-md-6 mb-4">
+    <%= render partial: "vote_distance" %>
+  </div>
+</div>
 <div class="row">
-  <%= render partial: "skipped_vote" %>
-  <%= render partial: "skipped_slot" %>
+  <div class="col-12 col-md-6 mb-4">
+    <%= render partial: "skipped_vote" %>
+  </div>
+  <div class="col-12 col-md-6 mb-4">
+    <%= render partial: "skipped_slot" %>
+  </div>
 </div>
 
 <div class="card">

--- a/app/views/cluster_stats/index.html.erb
+++ b/app/views/cluster_stats/index.html.erb
@@ -129,7 +129,7 @@
               <td>
                 <%= link_to record.last, validator_path(network: params[:network], account: record.last) %>
               </td>
-              <td><%= (record.first.to_f.round(3) * 100).to_s + "%" %></td>
+              <td><%= (record.first.to_f * 100).round(2).to_s + "%" %></td>
               <td class="text-right">
                 <%= link_to validator_path(network: params[:network], account: record.last) do %>
                   <i class="fas fa-search text-purple"></i>
@@ -222,7 +222,7 @@
               <td>
                 <%= link_to record.last, validator_path(network: params[:network], account: record.last) %>
               </td>
-              <td><%= ((record.first.to_f).round(3) * 100).to_s + "%" %></td>
+              <td><%= (record.first.to_f * 100).round(3).to_s + "%" %></td>
               <td class="text-right">
                 <%= link_to validator_path(network: params[:network], account: record.last) do %>
                   <i class="fas fa-search text-purple"></i>

--- a/app/views/cluster_stats/index.html.erb
+++ b/app/views/cluster_stats/index.html.erb
@@ -2,6 +2,15 @@
 <%= link_to 'Back to Homepage',
             url_for(controller: 'public', action: 'index', order: params[:order], page: params[:page], network: params[:network], refresh: params[:refresh]),
             class: 'btn btn-sm btn-secondary mb-3' %>
+
+<div class="row">
+  <%= render partial: "root_distance" %>
+  <%= render partial: "vote_distance" %>
+<div class="row">
+  <%= render partial: "skipped_vote" %>
+  <%= render partial: "skipped_slot" %>
+</div>
+
 <div class="card">
   <div class="card-content">
     <h3 class="card-heading mb-3">Top Validators by:</h3>
@@ -111,7 +120,7 @@
               <td>
                 <%= link_to record.last, validator_path(network: params[:network], account: record.last) %>
               </td>
-              <td><%= record.first.to_f.round(3) %></td>
+              <td><%= (record.first.to_f.round(3) * 100).to_s + "%" %></td>
               <td class="text-right">
                 <%= link_to validator_path(network: params[:network], account: record.last) do %>
                   <i class="fas fa-search text-purple"></i>
@@ -204,7 +213,7 @@
               <td>
                 <%= link_to record.last, validator_path(network: params[:network], account: record.last) %>
               </td>
-              <td><%= (record.first.to_f).round(3) %></td>
+              <td><%= ((record.first.to_f).round(3) * 100).to_s + "%" %></td>
               <td class="text-right">
                 <%= link_to validator_path(network: params[:network], account: record.last) do %>
                   <i class="fas fa-search text-purple"></i>
@@ -219,135 +228,7 @@
   </div>
 </div>
 
-<div class="row">
-  <div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Root Distance</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5 my-auto">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-purple">
-              <%= @stats[:root_distance][:median].to_i %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-purple">
-              <%= number_to_human(@stats[:root_distance][:average].to_f.round(1),
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted">
-              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
-              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
-            </div>
-            <div class="stat-title-2 text-purple">
-              <%= @stats[:root_distance][:min].to_i %> &ndash;
-              <%= number_to_human(@stats[:root_distance][:max].to_i,
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Vote Distance</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5 my-auto">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-purple">
-              <%= @stats[:vote_distance][:median].to_i %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-purple">
-              <%= number_to_human(@stats[:vote_distance][:average].to_f.round(1),
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted">
-              <i class="fas fa-long-arrow-alt-down text-purple"></i>Min &ndash;
-              <i class="fas fa-long-arrow-alt-up text-purple"></i>Max:
-            </div>
-            <div class="stat-title-2 text-purple">
-              <%= @stats[:vote_distance][:min].to_i %> &ndash;
-              <%= number_to_human(@stats[:vote_distance][:max].to_i,
-                                  format:'%n%u',
-                                  units: { thousand: 'K', million: 'M', billion: 'B' }) %>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Skipped Vote&nbsp;&percnt;</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-success">
-              <%= number_to_percentage @stats[:skipped_votes_percent][:median].to_f*100, precision: 1 %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-success">
-              <%= number_to_percentage @stats[:skipped_votes_percent][:average].to_f*100, precision: 1 %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted"><i class="fas fa-trophy text-success"></i>Best:</div>
-            <div class="stat-title-1 text-success">
-              <%= number_to_percentage @stats[:skipped_votes_percent][:best].to_f*100, precision: 2 %>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-12 col-md-6 mb-4">
-    <div class="card">
-      <div class="card-content">
-        <h3 class="card-heading mb-4">Skipped Slot&nbsp;&percnt;</h3>
-        <div class="row px-3 px-xl-5 mb-md-2">
-          <div class="stat col-5 my-auto">
-            <small class="text-muted">Median:</small>
-            <div class="h5 text-success">
-              <%= number_to_percentage @stats[:skipped_slots][:median].to_f * 100, precision: 1 %>
-            </div>
-            <small class="text-muted">Average:</small>
-            <div class="h5 text-success">
-              <%= number_to_percentage @stats[:skipped_slots][:average].to_f * 100, precision: 1 %>
-            </div>
-          </div>
-          <div class="stat col-7 my-auto px-0">
-            <div class="text-muted">
-              <i class="fas fa-long-arrow-alt-down text-success"></i>Min &ndash;
-              <i class="fas fa-long-arrow-alt-up text-success"></i>Max:
-            </div>
-            <h2 class="stat-title-2 text-success mt-2">
-              <% skipped_slots_min = @stats[:skipped_slots][:min].to_f * 100%>
-              <%= skipped_slots_min > 0 ? skipped_slots_min : 0 %>
-              &ndash; 
-              <%= @stats[:skipped_slots][:max].to_f * 100 %>
-            </h2>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
 
 <div class="row">
   <%= render 'validators/software_versions',


### PR DESCRIPTION
#### What's this PR do?
 - Put Root Distance, Vote Dist, Skipped Vote and Skipped Slots stats before "Top Validators by" block.
 - add percents to stats

#### How should this be manually tested?
see applied changes in cluster stats view

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/180047388

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
