### PR TITLE
180343870-fix-withdraw-authority-score

### DIFF
--- a/daemons/gather_vote_account_details_daemon.rb
+++ b/daemons/gather_vote_account_details_daemon.rb
@@ -7,7 +7,7 @@ class SkipAndSleep < StandardError; end
 begin
   loop do
     %w[mainnet testnet].each do |network|
-      config_urls = if @network == 'testnet'
+      config_urls = if network == 'testnet'
         Rails.application.credentials.solana[:testnet_urls]
       else
         Rails.application.credentials.solana[:mainnet_urls]


### PR DESCRIPTION
#### What's this PR do?
- withdraw-authority-score should be working on testnet

#### How should this be manually tested?
- run gather_vote_account_details_daemon.rb ( you can reverse order of networks at the top )
  and see if there are no errors. 

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/180343870

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
