### PR TITLE
180640347 mark removed validators

### DIFF
--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -10,6 +10,7 @@
 #  details             :string(191)
 #  info_pub_key        :string(191)
 #  is_active           :boolean          default(TRUE)
+#  is_destroyed        :boolean          default(FALSE)
 #  is_rpc              :boolean          default(FALSE)
 #  name                :string(191)
 #  network             :string(191)
@@ -35,8 +36,8 @@ class Validator < ApplicationRecord
     merge(ValidatorHistory.most_recent_epoch_credits_by_account)
   }, primary_key: :account, foreign_key: :account, class_name: 'ValidatorHistory'
 
-  scope :active, -> { where(is_active: true) }
-  scope :scorable, -> { where(is_active: true, is_rpc: false) }
+  scope :active, -> { where(is_active: true, is_destroyed: false) }
+  scope :scorable, -> { where(is_active: true, is_rpc: false, is_destroyed: false) }
 
   # after_save :copy_data_to_score
 

--- a/app/services/validator_check_active_service.rb
+++ b/app/services/validator_check_active_service.rb
@@ -30,9 +30,9 @@ class ValidatorCheckActiveService
   private
 
   def should_be_destroyed?(validator)
-    if validator.validator_histories.where("created_at > ?", @delinquent_time)
-      if validator.validator_histories.where('created_at < ?', @delinquent_time).exists?
-        true
+    if !validator.validator_histories.where("created_at < ?", @delinquent_time).exists?
+      if validator.validator_histories.where('created_at > ?', @delinquent_time).exists?
+        return true
       end
     end
 

--- a/app/services/validator_check_active_service.rb
+++ b/app/services/validator_check_active_service.rb
@@ -30,8 +30,8 @@ class ValidatorCheckActiveService
   private
 
   def should_be_destroyed?(validator)
-    if !validator.validator_histories.where("created_at < ?", @delinquent_time).exists?
-      if validator.validator_histories.where('created_at > ?', @delinquent_time).exists?
+    if !validator.validator_histories.where("created_at > ?", @delinquent_time.ago).exists?
+      if validator.validator_histories.where('created_at < ?', @delinquent_time.ago).exists?
         return true
       end
     end

--- a/db/migrate/20211220084849_add_is_destroyed_to_validators.rb
+++ b/db/migrate/20211220084849_add_is_destroyed_to_validators.rb
@@ -1,0 +1,5 @@
+class AddIsDestroyedToValidators < ActiveRecord::Migration[6.1]
+  def change
+    add_column :validators, :is_destroyed, :boolean, default: :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_15_082149) do
+ActiveRecord::Schema.define(version: 2021_12_20_084849) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -492,6 +492,7 @@ ActiveRecord::Schema.define(version: 2021_12_15_082149) do
     t.string "security_report_url"
     t.boolean "is_rpc", default: false
     t.boolean "is_active", default: true
+    t.boolean "is_destroyed", default: false
     t.index ["network", "account"], name: "index_validators_on_network_and_account", unique: true
   end
 

--- a/test/services/validator_check_active_service_test.rb
+++ b/test/services/validator_check_active_service_test.rb
@@ -90,4 +90,15 @@ class ValidatorCheckActiveWorkerTest < ActiveSupport::TestCase
     assert v.reload.is_destroyed
   end
 
+  test "validator with recent history should not be marked as destroyed" do
+    v = create(:validator, :with_score, account: "account7")
+    create(:validator_history, account: "account7", created_at: 22.hours.ago)
+
+    refute v.is_destroyed
+
+    ValidatorCheckActiveService.new.update_validator_activity
+
+    refute v.reload.is_destroyed
+  end
+
 end

--- a/test/services/validator_check_active_service_test.rb
+++ b/test/services/validator_check_active_service_test.rb
@@ -79,4 +79,15 @@ class ValidatorCheckActiveWorkerTest < ActiveSupport::TestCase
     refute v.reload.is_active
   end
 
+  test "validator with no recent history should be marked as destroyed" do
+    v = create(:validator, :with_score, account: "account6")
+    create(:validator_history, account: "account6", created_at: 25.hours.ago)
+
+    refute v.is_destroyed
+
+    ValidatorCheckActiveService.new.update_validator_activity
+
+    assert v.reload.is_destroyed
+  end
+
 end


### PR DESCRIPTION
#### What's this PR do?
- mark validators that are no longer in solana as destroyed

#### How should this be manually tested?
- run tests
- try to run `ValidatorCheckActiveService.new.update_validator_activity` in rails console after running daemons for a while, although it's not certain that there will be any marked
- already tested on stage and there are some validators marked 

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/180640347)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
