### PR TITLE
180873430 hide stake accounts with no stake

### DIFF
--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -142,7 +142,7 @@ module StakeLogic
       return p unless p.code == 200
 
       p.payload[:stake_pools].each do |pool|
-        validator_ids = pool.stake_accounts.pluck(:validator_id)
+        validator_ids = pool.stake_accounts.active.pluck(:validator_id)
         delinquent_count = 0
         last_skipped_slots = []
         uptimes = []
@@ -189,7 +189,7 @@ module StakeLogic
       return p unless p.code == 200
 
       StakePool.where(network: p.payload[:network]).each do |pool|
-        validator_ids = pool.stake_accounts.pluck(:validator_id)
+        validator_ids = pool.stake_accounts.active.pluck(:validator_id)
         average_commission = ValidatorScoreV1.where(validator_id: validator_ids)
                                              .average(:commission)
 

--- a/app/models/stake_account.rb
+++ b/app/models/stake_account.rb
@@ -40,4 +40,5 @@ class StakeAccount < ApplicationRecord
   scope :filter_by_account, ->(account) { where('stake_pubkey LIKE ?', "#{account}%") }
   scope :filter_by_staker, ->(staker) { where('staker LIKE ?', "#{staker}%") }
   scope :filter_by_withdrawer, ->(withdrawer) { where('withdrawer LIKE ?', "#{withdrawer}%") }
+  scope :active, ->() { where.not(active_stake: [0, nil]) }
 end

--- a/app/queries/stake_account_query.rb
+++ b/app/queries/stake_account_query.rb
@@ -39,8 +39,9 @@ class StakeAccountQuery
                                  .left_outer_joins(:validator)
                                  .select(query_fields)
                                  .where(
-                                   network: @network
+                                   network: @network,
                                  )
+                                 .where.not(active_stake: [nil, 0])
 
     stake_accounts = stake_accounts.filter_by_account(@filter_by[:account]) \
       unless @filter_by[:account].blank?

--- a/app/queries/stake_account_query.rb
+++ b/app/queries/stake_account_query.rb
@@ -41,7 +41,7 @@ class StakeAccountQuery
                                  .where(
                                    network: @network,
                                  )
-                                 .where.not(active_stake: [nil, 0])
+                                 .active
 
     stake_accounts = stake_accounts.filter_by_account(@filter_by[:account]) \
       unless @filter_by[:account].blank?

--- a/test/queries/stake_account_query_test.rb
+++ b/test/queries/stake_account_query_test.rb
@@ -34,6 +34,20 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     create(
       :stake_account,
+      active_stake: nil,
+      delegated_stake: 100,
+      staker: 'staker_key',
+      withdrawer: @stake_pool.authority,
+      network: 'testnet',
+      stake_pubkey: 'stake_pubkey_1',
+      validator: @validator,
+      stake_pool: @stake_pool,
+      activation_epoch: 1,
+      batch_uuid: 'batch'
+    )
+
+    create(
+      :stake_account,
       active_stake: 200,
       delegated_stake: 200,
       staker: 'diff_staker_key',
@@ -60,6 +74,7 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     assert_equal 2, stake_accounts.size
     assert_equal 1, stake_accounts.first.activation_epoch
+    refute stake_accounts.where(active_stake: nil).exists?
   end
 
   test 'when filter_account provided return correct records' do
@@ -77,6 +92,7 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     assert_equal 1, stake_accounts.size
     assert_equal 'stake_pubkey_1', stake_accounts.first.stake_pubkey
+    refute stake_accounts.where(active_stake: nil).exists?
   end
 
   test 'when filter_staker provided return correct records' do
@@ -94,6 +110,7 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     assert_equal 1, stake_accounts.size
     assert_equal 'staker_key', stake_accounts.first.staker
+    refute stake_accounts.where(active_stake: nil).exists?
   end
 
   test 'when filter_withdrawer provided return correct records' do
@@ -111,6 +128,7 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     assert_equal 1, stake_accounts.size
     assert_equal @stake_pool.authority, stake_accounts.first.withdrawer
+    refute stake_accounts.where(active_stake: nil).exists?
   end
 
   test 'when filter_validator provided return correct records' do
@@ -128,6 +146,7 @@ class StakeAccountQueryTest < ActiveSupport::TestCase
 
     assert_equal 1, stake_accounts.size
     assert_equal @validator.name, stake_accounts.first.validator_name
+    refute stake_accounts.where(active_stake: nil).exists?
   end
 
 end


### PR DESCRIPTION
#### What's this PR do?
- active stake should not be displayed and should not be counted for stake pool averages

#### How should this be manually tested?
- check /stake_accounts page and check if there are any accounts with 0 stake
- run tests

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/180873430)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
