### PR TITLE
180932001-reset-is_destroyed-when-necessery

### DIFF
--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -82,7 +82,7 @@ class Validator < ApplicationRecord
   end
 
   def scorable?
-    is_active && !is_rpc
+    is_active && !is_rpc && !is_destroyed
   end
 
   def validator_history_last

--- a/app/services/validator_check_active_service.rb
+++ b/app/services/validator_check_active_service.rb
@@ -17,7 +17,7 @@ class ValidatorCheckActiveService
       else
         # Check validators that are currently not scorable in case they reactivate
         if acceptable_stake?(validator) && not_delinquent?(validator)
-          validator.update(is_active: true)
+          validator.update(is_active: true, is_destroyed: false)
 
         # Check if vote account has been created for rpc_node
         elsif validator.vote_accounts.exists?

--- a/test/services/validator_check_active_service_test.rb
+++ b/test/services/validator_check_active_service_test.rb
@@ -101,4 +101,15 @@ class ValidatorCheckActiveWorkerTest < ActiveSupport::TestCase
     refute v.reload.is_destroyed
   end
 
+  test "validator with recent history that is marked as destroyed should not be destroyed" do
+    v = create(:validator, :with_score, account: "account7", is_destroyed: true)
+    create(:validator_history, account: "account7", created_at: 22.hours.ago)
+
+    assert v.is_destroyed
+
+    ValidatorCheckActiveService.new.update_validator_activity
+
+    refute v.reload.is_destroyed
+  end
+
 end


### PR DESCRIPTION
#### What's this PR do?
- If validator is marked as destroyed, it should be unmarked when it is active again
- 
#### How should this be manually tested?
- run tests
- set any validators is_destroyed to true and run ValidatorCheckActiveWorker
- is_destroyed for this validator should go back to false

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/180932001)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
