### PR TITLE
180903060_tweak_displaying_0_stake_pool_values

### DIFF
--- a/app/javascript/packs/stake_accounts/pool_stats.js
+++ b/app/javascript/packs/stake_accounts/pool_stats.js
@@ -23,7 +23,7 @@ var StakePoolStats = Vue.component('StakePoolStats', {
         <h3 class="card-heading">
           {{ pool.name }} {{ pool.ticker ? '(' + pool.ticker + ')' : '' }} statistics
         </h3>
-        
+
         <div class="row pl-lg-4 pl-xl-5">
           <div class="col-md-4 pl-lg-4 pl-xl-5">
             <div class="mb-2">
@@ -48,24 +48,24 @@ var StakePoolStats = Vue.component('StakePoolStats', {
               <strong class="text-purple">{{ (total_stake / 1000000000).toLocaleString('en-US', {maximumFractionDigits: 0}) }} SOL</strong>
             </div>
           </div>
-          
+
           <div class="col-md-4 pl-lg-4 pl-xl-5">
             <div class="stat-title-3 mb-2">
               <i class="fas fa-hand-holding-usd text-success mr-2"></i>Fees
-            </div> 
+            </div>
             <div>
               <span class="text-muted">Manager Fee:&nbsp;</span>
-              <strong class="text-success">{{ pool.manager_fee ? pool.manager_fee + '%' : 'N / A' }}</strong>
+              <strong class="text-success">{{ pool.manager_fee ? pool.manager_fee + '%' : 0 }}</strong>
             </div>
             <div class="mb-4">
               <span class="text-muted">Avg Commission:&nbsp;</span>
-              <strong class="text-success">{{ pool.average_validators_commission ? pool.average_validators_commission.toFixed(2) : 'N / A' }}%</strong>
+              <strong class="text-success">{{ pool.average_validators_commission ? pool.average_validators_commission.toFixed(2) : 0 }}%</strong>
             </div>
             <div class="mb-3">
               <span class="stat-title-3">
                 <i class="fas fa-chart-line text-purple mr-2"></i>APY:&nbsp;
               </span>
-              <strong class="text-purple">{{ pool.average_apy ? pool.average_apy.toFixed(2) + '%' : 'N / A' }}</strong>
+              <strong class="text-purple">{{ pool.average_apy ? pool.average_apy.toFixed(2) + '%' : 0 }}</strong>
             </div>
           </div>
 
@@ -77,19 +77,19 @@ var StakePoolStats = Vue.component('StakePoolStats', {
             </div>
             <div>
               <span class="text-muted">Avg Skipped Slots:&nbsp;</span>
-              <strong class="text-success">{{ pool.average_skipped_slots ? pool.average_skipped_slots.toFixed(2) : 'N / A' }}&percnt;</strong>
+              <strong class="text-success">{{ pool.average_skipped_slots ? pool.average_skipped_slots.toFixed(2) : 0 }}&percnt;</strong>
             </div>
             <div>
               <span class="text-muted">Avg Lifetime:&nbsp;</span>
-              <strong class="text-success">{{ pool.average_lifetime ? pool.average_lifetime + ' days' : 'N / A' }}</strong>
+              <strong class="text-success">{{ pool.average_lifetime ? pool.average_lifetime + ' days' : 0 }}</strong>
             </div>
             <div>
               <span class="text-muted">Avg Uptime:&nbsp;</span>
-              <strong class="text-success">{{ pool.average_uptime ? pool.average_uptime.toFixed(1) + ' days': 'N / A' }}</strong>
+              <strong class="text-success">{{ pool.average_uptime ? pool.average_uptime.toFixed(1) + ' days': 0 }}</strong>
             </div>
             <div class="">
               <span class="text-muted">Avg Score:&nbsp;</span>
-              <strong class="text-success">{{ pool.average_score || 'N / A' }}</strong>
+              <strong class="text-success">{{ pool.average_score || 0 }}</strong>
             </div>
           </div>
         </div>

--- a/app/javascript/packs/stake_accounts/pool_stats.js
+++ b/app/javascript/packs/stake_accounts/pool_stats.js
@@ -70,7 +70,7 @@ var StakePoolStats = Vue.component('StakePoolStats', {
               <span class="stat-title-3">
                 <i class="fas fa-chart-line text-purple mr-2"></i>APY:&nbsp;
               </span>
-              <strong class="text-purple">{{ pool.average_apy ? pool.average_apy.toFixed(2) + '%' : 0 }}</strong>
+              <strong class="text-purple">{{ pool.average_apy ? pool.average_apy.toFixed(2) + '%' : 'N / A' }}</strong>
             </div>
           </div>
 


### PR DESCRIPTION
#### What's this PR do?
- tweak displaying 0 stake pool values

#### How should this be manually tested?
- Go to localhost:3000/stake-pools, choose ie. jpool, values in statistics should be 0 not 'N / A'

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/180903060

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
