### PR TITLE
180905301 randomize stake accounts order

### DIFF
--- a/app/controllers/api/v1/stake_accounts_controller.rb
+++ b/app/controllers/api/v1/stake_accounts_controller.rb
@@ -18,7 +18,8 @@ module Api
         @total_stake = stake_accounts&.map(&:delegated_stake).compact.sum
         stake_accounts = stake_accounts.group_by(&:delegated_vote_account_address)
         @total_count = stake_accounts.keys.size
-        sa_keys = stake_accounts.keys[((page - 1) * 20)...((page - 1) * 20 + 20)]
+        sa_keys = stake_accounts.keys.shuffle(random: random_by_seed(seed: index_params[:seed].to_i))
+        sa_keys = sa_keys[((page - 1) * 20)...((page - 1) * 20 + 20)]
         @stake_accounts = sa_keys&.map {|k| {stake_accounts[k][0].validator_account => stake_accounts[k]}}
 
         if index_params[:with_batch]
@@ -27,6 +28,10 @@ module Api
       end
 
       private
+
+      def random_by_seed(seed: )
+        Random.new(seed || rand(1..1000))
+      end
 
       def index_params
         params.permit(
@@ -38,7 +43,8 @@ module Api
           :filter_staker,
           :filter_withdrawer,
           :filter_validator,
-          :with_batch
+          :with_batch,
+          :seed
         ) 
       end
     end

--- a/app/javascript/packs/stake_accounts/index_template.vue
+++ b/app/javascript/packs/stake_accounts/index_template.vue
@@ -183,6 +183,7 @@
         selected_pool: null,
         batch: null,
         loading_image: loadingImage,
+        seed: Math.floor(Math.random() * 1000),
         pool_images: {
           marinade: marinadeImage,
           socean: soceanImage,
@@ -194,7 +195,7 @@
     },
     created () {
       var ctx = this
-      var query_params = { params: { sort_by: ctx.sort_by, page: ctx.page, with_batch: true } }
+      var query_params = { params: { sort_by: ctx.sort_by, page: ctx.page, with_batch: true, seed: ctx.seed } }
 
       axios.get(ctx.api_url, query_params)
            .then(function (response){

--- a/app/javascript/packs/stake_accounts/index_template.vue
+++ b/app/javascript/packs/stake_accounts/index_template.vue
@@ -241,7 +241,8 @@
             filter_account: ctx.filter_account,
             filter_staker: ctx.filter_staker,
             filter_withdrawer: ctx.filter_withdrawer,
-            filter_validator: ctx.filter_validator
+            filter_validator: ctx.filter_validator,
+            seed: ctx.seed
           }
         }
 


### PR DESCRIPTION
#### What's this PR do?
- stake accounts in stake pools view should be in random order

#### How should this be manually tested?
-visit the /stake-pools page and check if order is random each time the page reloads. order should stay the same during pagination

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/180905301)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
