### PR TITLE
Tweak displaying small stake

### DIFF
--- a/app/javascript/packs/stake_accounts/stake_account_row.js
+++ b/app/javascript/packs/stake_accounts/stake_account_row.js
@@ -74,7 +74,13 @@ var StakeAccountRow = Vue.component('StakeAccountRow', {
                 <!--<a href="#" title="Filter by withdrawer" @click.prevent="filterByWithdrawer">{{ stake_account.withdrawer }}</a>-->
               </td>
               <td>
-                <strong class="d-inline-block d-lg-none">Stake:&nbsp;&nbsp;</strong>{{ (stake_account.active_stake / 1000000000).toLocaleString('en-US', {maximumFractionDigits: 0}) }} SOL
+                <strong class="d-inline-block d-lg-none">Stake:&nbsp;&nbsp;</strong>
+                <span v-if="stake_account.active_stake < 500000000">
+                  <0.5 SOL
+                </span>
+                <span v-else>
+                  {{ (stake_account.active_stake / 1000000000).toLocaleString('en-US', {maximumFractionDigits: 0}) }} SOL
+                </span>
               </td>
               <td class="text-lg-right">
                 <strong class="d-inline-block d-lg-none">Activation Epoch:&nbsp;&nbsp;</strong>{{ stake_account.activation_epoch }}


### PR DESCRIPTION
#### What's this PR do?
- For stake smaller than 0.5 SOL do not round to 0, but display "<0.5"

#### How should this be manually tested?
- Check an account with small stake (eg. stake account 7DBSpxcymkAjkFjLF9hcw7MNtfzSSD6KuDDFuy6BKh4b or account 5C8xyL5ESXv6PqJexW5RATEBgLKvcVR3dEHxhmLSEkaZ) before and after change indroduced in this PR. The stake should no longer be displayed as "0"

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/180887252)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
