### PR TITLE
181049608 do not display zero scores

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -172,7 +172,8 @@ module Api
           'network',
           'updated_at',
           'www_url',
-          'avatar_url'
+          'avatar_url',
+          'admin_warning'
         ].map { |e| "validators.#{e}" }
       end
 

--- a/app/javascript/packs/stake_accounts/validator_row.js
+++ b/app/javascript/packs/stake_accounts/validator_row.js
@@ -110,7 +110,16 @@ var ValidatorRow = Vue.component('validatorRow', {
           l.classList.remove('active')
       });
       event.target.classList.add('active');
-    }
+    },
+    displayed_total_score() {
+      if(this.validator["commission"] == 100 && this.validator["network"] == 'mainnet'){
+        return 'N/A'
+      } else if(this.validator["admin_warning"]) {
+        return 'N/A'
+      } else {
+        return this.validator["total_score"]
+      }
+    },
   },
   template: `
     <tr :id="row_index()">
@@ -160,7 +169,7 @@ var ValidatorRow = Vue.component('validatorRow', {
           <i class="fas fa-minus-circle mr-1 text-warning"
             v-if="validator['data_center_concentration_score'] < 0"
             :title=" 'Data Center Concentration Score = ' + validator['data_center_concentration_score'] "></i>
-          (<span class="d-inline-block d-lg-none">Total:&nbsp;</span>{{ validator['total_score'] == 0 ? 'N/A' : validator['total_score'] }})
+          (<span class="d-inline-block d-lg-none">Total:&nbsp;</span>{{ displayed_total_score() }})
         </small>
         <br /><small v-if="validator['delinquent']" class="text-danger">delinquent</small>
       </td>

--- a/app/javascript/packs/stake_accounts/validator_row.js
+++ b/app/javascript/packs/stake_accounts/validator_row.js
@@ -160,7 +160,7 @@ var ValidatorRow = Vue.component('validatorRow', {
           <i class="fas fa-minus-circle mr-1 text-warning"
             v-if="validator['data_center_concentration_score'] < 0"
             :title=" 'Data Center Concentration Score = ' + validator['data_center_concentration_score'] "></i>
-          (<span class="d-inline-block d-lg-none">Total:&nbsp;</span>{{ validator['total_score'] }})
+          (<span class="d-inline-block d-lg-none">Total:&nbsp;</span>{{ validator['total_score'] == 0 ? 'N/A' : validator['total_score'] }})
         </small>
         <br /><small v-if="validator['delinquent']" class="text-danger">delinquent</small>
       </td>

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -247,7 +247,8 @@ class Validator < ApplicationRecord
         :details,
         :avatar_url,
         :created_at,
-        :updated_at
+        :updated_at,
+        :admin_warning
       )
     end
   end

--- a/app/models/validator_score_v1.rb
+++ b/app/models/validator_score_v1.rb
@@ -149,6 +149,12 @@ class ValidatorScoreV1 < ApplicationRecord
       end
   end
 
+  def displayed_total_score
+    return 'N/A' if validator.private_validator?
+    return 'N/A' if validator.admin_warning
+    total_score
+  end
+
   def delinquent?
     delinquent == true
   end

--- a/app/models/validator_score_v1.rb
+++ b/app/models/validator_score_v1.rb
@@ -150,8 +150,8 @@ class ValidatorScoreV1 < ApplicationRecord
   end
 
   def displayed_total_score
-    return 'N/A' if validator.private_validator?
-    return 'N/A' if validator.admin_warning
+    return "N/A" if validator.private_validator?
+    return "N/A" if validator.admin_warning
     total_score
   end
 

--- a/app/views/validators/_scores.html.erb
+++ b/app/views/validators/_scores.html.erb
@@ -32,5 +32,5 @@
        title="Data Center Concentration Score = <%= validator.data_center_concentration_score %>"></i>
   <% end %>
 
-  (<span class="d-inline-block d-lg-none">Total:&nbsp;</span><%= validator.total_score %>)
+  (<span class="d-inline-block d-lg-none">Total:&nbsp;</span><%= validator.score.displayed_total_score %>)
 </small>

--- a/test/controllers/api/v1/api_controller_test.rb
+++ b/test/controllers/api/v1/api_controller_test.rb
@@ -114,7 +114,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, json.size
 
     # Adjust after adding/removing attributes in json builder
-    assert_equal 33, validator_with_all_data.keys.size
+    assert_equal 34, validator_with_all_data.keys.size
 
     # Validator
     assert_equal 'testnet', validator_with_all_data['network']
@@ -295,7 +295,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     validator_active_stake = validator.validator_score_v1.active_stake
 
     # Adjust after adding/removing attributes in json builder
-    assert_equal 33, json_response.keys.size
+    assert_equal 34, json_response.keys.size
 
     # Validator
     assert_equal 'testnet', json_response['network']
@@ -357,7 +357,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     validator_active_stake = validator.validator_score_v1.active_stake
 
     # Adjust after adding/removing attributes in json builder
-    assert_equal 39, json_response.keys.size
+    assert_equal 40, json_response.keys.size
 
     # Score
     assert_equal [1, 2, 3, 4, 5], json_response["root_distance_history"]

--- a/test/models/validator_score_v1_test.rb
+++ b/test/models/validator_score_v1_test.rb
@@ -35,6 +35,7 @@ class ValidatorScoreV1Test < ActiveSupport::TestCase
     )
 
     assert_equal 0, @validator_score_v1.total_score
+    assert_equal 'N/A', @validator_score_v1.displayed_total_score
   end
 
   test 'calculate_total_score assigns a score of 0 if validator has admin_warning' do
@@ -42,6 +43,7 @@ class ValidatorScoreV1Test < ActiveSupport::TestCase
     @validator_score_v1.calculate_total_score
 
     assert_equal 0, @validator_score_v1.total_score
+    assert_equal 'N/A', @validator_score_v1.displayed_total_score
   end
 
   test 'calculate_total_score correctly calculate score' do

--- a/test/models/validator_score_v1_test.rb
+++ b/test/models/validator_score_v1_test.rb
@@ -35,7 +35,7 @@ class ValidatorScoreV1Test < ActiveSupport::TestCase
     )
 
     assert_equal 0, @validator_score_v1.total_score
-    assert_equal 'N/A', @validator_score_v1.displayed_total_score
+    assert_equal "N/A", @validator_score_v1.displayed_total_score
   end
 
   test 'calculate_total_score assigns a score of 0 if validator has admin_warning' do
@@ -43,7 +43,7 @@ class ValidatorScoreV1Test < ActiveSupport::TestCase
     @validator_score_v1.calculate_total_score
 
     assert_equal 0, @validator_score_v1.total_score
-    assert_equal 'N/A', @validator_score_v1.displayed_total_score
+    assert_equal "N/A", @validator_score_v1.displayed_total_score
   end
 
   test 'calculate_total_score correctly calculate score' do


### PR DESCRIPTION
#### What's this PR do?
- If score is 0 because validator is private or has admin_warning, display 'N/A' in views. Keep 0 in db.

#### How should this be manually tested?
- Review on homepage, validator details page and stake pools page.

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/181049608)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
