### PR TITLE
181111955 rescue from no stake accounts

### DIFF
--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -29,6 +29,8 @@ module StakeLogic
         p.payload[:config_urls]
       )
 
+      raise 'No results from `solana stakes`' if stake_accounts.blank?
+
       reduced_stake_accounts = []
 
       StakePool.where(network: p.payload[:network]).each do |pool|

--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -4,6 +4,8 @@ module StakeLogic
   include PipelineLogic
   include SolanaLogic #for solana_client_request
 
+  class NoResultsFromSolana < StandardError; end
+
   def get_last_batch
     lambda do |p|
       return p unless p.code == 200
@@ -29,7 +31,7 @@ module StakeLogic
         p.payload[:config_urls]
       )
 
-      raise 'No results from `solana stakes`' if stake_accounts.blank?
+      raise NoResultsFromSolana.new('No results from `solana stakes`') if stake_accounts.blank?
 
       reduced_stake_accounts = []
 
@@ -213,7 +215,7 @@ module StakeLogic
         params: [stake_accounts.pluck(:stake_pubkey)]
       )
 
-      raise 'No results from `get_inflation_reward`' \
+      raise NoResultsFromSolana.new('No results from `get_inflation_reward`') \
         if reward_info.blank?
 
       account_rewards = {}

--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -213,6 +213,9 @@ module StakeLogic
         params: [stake_accounts.pluck(:stake_pubkey)]
       )
 
+      raise 'No results from `get_inflation_reward`' \
+        if reward_info.blank?
+
       account_rewards = {}
 
       stake_accounts.each_with_index do |sa, idx|

--- a/test/logic/stake_logic_empty_responses_test.rb
+++ b/test/logic/stake_logic_empty_responses_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class StakeLogicEmptyResponsesTest < ActiveSupport::TestCase
+  include StakeLogic
+
+  # overwrite cli_request to return empty response
+  def cli_request(cli_method, rpc_urls)
+    {}
+  end
+  # overwrite solana_client_request to return empty response
+  def solana_client_request(clusters, method, params: [], use_token: false)
+    {}
+  end
+
+  setup do
+    @initial_payload = {
+      # config_urls: Rails.application.credentials.solana[:testnet_urls],
+      config_urls: [
+        @testnet_url
+      ],
+      network: 'testnet'
+    }
+  end
+
+  test "get_stake_accounts \
+        when getting no response \
+        should raise error" do
+    authority = 'H2qwtMNNFh6euD3ym4HLgpkbNY6vMdf5aX5bazkU4y8b'
+    create(:stake_pool, authority: authority, network: 'testnet')
+
+    p = Pipeline.new(200, @initial_payload)
+                .then(&get_last_batch)
+                .then(&get_stake_accounts)
+
+    assert_nil p[:payload][:stake_accounts]
+    assert_equal "No results from `solana stakes`", p.errors.message
+    assert_equal NoResultsFromSolana, p.errors.class
+    assert_equal 500, p.code
+  end
+
+  test "get_rewards \
+    when response is empty \
+    should raise error" do
+    stake_pool = create(:stake_pool)
+    validator = create(:validator)
+    validator2 = create(:validator)
+    score = create(:validator_score_v1, validator: validator)
+    score2 = create(:validator_score_v1, validator: validator2)
+    score.update_columns(total_score: 10)
+    score2.update_columns(total_score: 9)
+    create(:stake_account, validator: validator, stake_pool: stake_pool)
+    create(:stake_account, validator: validator2, stake_pool: stake_pool)
+
+    p = Pipeline.new(200, @initial_payload)
+              .then(&get_rewards)
+
+    assert_equal "No results from `get_inflation_reward`", p.errors.message
+    assert_equal NoResultsFromSolana, p.errors.class
+    assert_equal 500, p.code
+  end
+end

--- a/test/logic/stake_logic_empty_responses_test.rb
+++ b/test/logic/stake_logic_empty_responses_test.rb
@@ -39,8 +39,8 @@ class StakeLogicEmptyResponsesTest < ActiveSupport::TestCase
   end
 
   test "get_rewards \
-    when response is empty \
-    should raise error" do
+       when response is empty \
+       should raise error" do
     stake_pool = create(:stake_pool)
     validator = create(:validator)
     validator2 = create(:validator)

--- a/test/logic/stake_logic_test.rb
+++ b/test/logic/stake_logic_test.rb
@@ -224,7 +224,9 @@ class StakeLogicTest < ActiveSupport::TestCase
     assert_equal 6.67, stake_pool.reload.average_score
   end
 
-  test "get_rewards" do
+  test "get_rewards \
+        when response is correct \
+        should have correct payload" do
     stake_pool = create(:stake_pool)
     validator = create(:validator)
     validator2 = create(:validator)

--- a/test/logic/stake_logic_test.rb
+++ b/test/logic/stake_logic_test.rb
@@ -59,22 +59,6 @@ class StakeLogicTest < ActiveSupport::TestCase
     end
   end
 
-  test "get_stake_accounts \
-        when getting no response \
-        should raise error" do
-    authority = 'H2qwtMNNFh6euD3ym4HLgpkbNY6vMdf5aX5bazkU4y8b'
-    create(:stake_pool, authority: authority, network: 'testnet')
-
-    SolanaCliService.stub(:request, [], ['stakes', @testnet_url]) do
-      p = Pipeline.new(200, @initial_payload)
-                  .then(&get_last_batch)
-                  .then(&get_stake_accounts)
-
-      assert_nil p[:payload][:stake_accounts]
-      assert_equal 500, p.code
-    end
-  end
-
   test 'update_stake_accounts' do
     SolanaCliService.stub(:request, @json_data, ['stakes', @testnet_url]) do
       p = Pipeline.new(200, @initial_payload)


### PR DESCRIPTION
#### What's this PR do?
- If there is no response with stake_accounts from solana, nothing should be deleted.

#### How should this be manually tested?
- run tests
- try to run dev/stake_logic_demo.rb with changed urls and see if the behavior is correct

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/181111955)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
