### PR TITLE
 181071554_add_link_to_delegation_strategy

### DIFF
--- a/app/javascript/packs/stake_accounts/pool_stats.js
+++ b/app/javascript/packs/stake_accounts/pool_stats.js
@@ -1,5 +1,13 @@
 import Vue from 'vue/dist/vue.esm'
 
+const DELEGATION_STRATEGY_URLS = {
+  "DAOPool": "https://solana.foundation/stake-pools",
+  "Jpool": "https://docs.jpool.one/technical-stuff/staking-strategy",
+  "Marinade": "https://docs.marinade.finance/marinade-protocol/validators",
+  "Lido": "https://solana.foundation/stake-pools",
+  "Socean": "https://docs.socean.fi/whitepaper#delegation-strategy"
+}
+
 var StakePoolStats = Vue.component('StakePoolStats', {
   props: {
     pool: {
@@ -11,8 +19,8 @@ var StakePoolStats = Vue.component('StakePoolStats', {
     return {}
   },
   methods: {
-    go_to_metrics() {
-      document.getElementById("metrics").scrollIntoView()
+    delegation_strategy_url() {
+      return DELEGATION_STRATEGY_URLS[this.pool.name]
     }
   },
   template: `
@@ -22,7 +30,7 @@ var StakePoolStats = Vue.component('StakePoolStats', {
           {{ pool.name }} {{ pool.ticker ? '(' + pool.ticker + ')' : '' }} Statistics
         </h3>
         <div class="text-center text-muted small mb-4">
-          <a href="#" @click.prevent="go_to_metrics()">See metrics explanation</a>
+          <a v-bind:href="delegation_strategy_url()" target="_blank">See delegation strategy</a>
         </div>
 
         <div class="row pl-lg-4 pl-xl-5">

--- a/app/javascript/packs/stake_accounts/pool_stats.js
+++ b/app/javascript/packs/stake_accounts/pool_stats.js
@@ -1,11 +1,11 @@
 import Vue from 'vue/dist/vue.esm'
 
 const DELEGATION_STRATEGY_URLS = {
-  "DAOPool": "https://solana.foundation/stake-pools",
+  "DAOPool": "https://monkedao.medium.com/daosol-the-next-step-in-decentralizing-solana-7519e3b2bded",
   "Jpool": "https://docs.jpool.one/technical-stuff/staking-strategy",
   "Marinade": "https://docs.marinade.finance/marinade-protocol/validators",
   "Lido": "https://solana.foundation/stake-pools",
-  "Socean": "https://docs.socean.fi/whitepaper#delegation-strategy"
+  "Socean": "https://docs.socean.fi/faq#how-does-socean-delegate-my-funds"
 }
 
 var StakePoolStats = Vue.component('StakePoolStats', {


### PR DESCRIPTION
Change link to metrics explanation to link to delegation strategy in stake pool stats

#### What's this PR do?
- Adds links to delegation strategy to stake pools

#### How should this be manually tested?
- Go to /stake-pools
- Filter by each stake pool to see stats
- You should see the link under the name of the stake pool "See delegation strategy" - check it for every validator

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/181071554

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
