### PR TITLE
181341014 sort pings by reported at

### DIFF
--- a/app/controllers/api/v1/ping_things_controller.rb
+++ b/app/controllers/api/v1/ping_things_controller.rb
@@ -12,6 +12,7 @@ module Api
         limit = [(index_params[:limit] || 240).to_i, 11520].min
         ping_things = PingThing.where(network: index_params[:network])
                                .includes(:user)
+                               .order(reported_at: :desc)
                                .last(limit)
         json_result = ping_things.map { |pt| create_json_result(pt) }
         render json: json_result

--- a/app/controllers/api/v1/ping_things_controller.rb
+++ b/app/controllers/api/v1/ping_things_controller.rb
@@ -12,7 +12,7 @@ module Api
         limit = [(index_params[:limit] || 240).to_i, 11520].min
         ping_things = PingThing.where(network: index_params[:network])
                                .includes(:user)
-                               .order(reported_at: :desc)
+                               .order(reported_at: :asc)
                                .last(limit)
         json_result = ping_things.map { |pt| create_json_result(pt) }
         render json: json_result

--- a/app/controllers/ping_things_controller.rb
+++ b/app/controllers/ping_things_controller.rb
@@ -4,7 +4,7 @@ class PingThingsController < ApplicationController
   def index
     @ping_things = PingThing.where(network: params[:network])
                             .includes(:user)
-                            .order(created_at: :desc)
+                            .order(reported_at: :desc)
                             .first(240)
     @ping_things_count = @ping_things.length
     @ping_things_array_for_chart = @ping_things.pluck(:response_time).reverse

--- a/app/models/ping_thing.rb
+++ b/app/models/ping_thing.rb
@@ -22,7 +22,7 @@
 #
 #  index_ping_things_on_created_at_and_network_and_transaction_type  (created_at,network,transaction_type)
 #  index_ping_things_on_created_at_and_network_and_user_id           (created_at,network,user_id)
-#  index_ping_things_on_reported_at                                  (reported_at)
+#  index_ping_things_on_reported_at_and_network                      (reported_at,network)
 #  index_ping_things_on_user_id                                      (user_id)
 #
 # Foreign Keys

--- a/app/models/ping_thing.rb
+++ b/app/models/ping_thing.rb
@@ -50,7 +50,8 @@ class PingThing < ApplicationRecord
         :response_time,
         :signature,
         :success,
-        :transaction_type
+        :transaction_type,
+        :reported_at
       )
     end
   end

--- a/app/views/ping_things/index.html.erb
+++ b/app/views/ping_things/index.html.erb
@@ -41,7 +41,7 @@
       <tr>
         <th class="align-middle column-md-sm">Success / Time</th>
         <th class="align-middle column-lg">
-          Created&nbsp;At<br />
+          Reported&nbsp;At<br />
           <span class="small text-muted">Signature</span>
         </th>
         <th class="align-middle column-lg">
@@ -60,7 +60,7 @@
             <strong class="text-success h6"><%= number_with_delimiter(pt.response_time) %></strong>&nbsp;ms
           </td>
           <td class="align-middle small">
-            <%= pt.created_at %><br />
+            <%= pt.reported_at %><br />
             <span class="word-break"><%= link_to shorten_key(pt.signature), link_from_signature(pt.signature), target: "_blank", class: "small"%></span>
           </td>
           <td class="align-middle small">

--- a/app/views/public/api_documentation.html.erb
+++ b/app/views/public/api_documentation.html.erb
@@ -400,6 +400,7 @@ curl -X POST -H "Token: secret-api-token" -H "Content-Type: application/json" -d
     "signature": "0d7f418e4d1a3f80dc8a266cd867f766b73d9c80feea36524dfd074068bdef9221e356c192ac6ac71b71404d",
     "success": true,
     "transaction_type": "transfer",
+    "reported_at": "2022-02-10T13:31:55.000Z"
     "username": "sample_user"
   },
   ...

--- a/db/migrate/20220224142533_fix_index_on_reported_at_to_ping_thing.rb
+++ b/db/migrate/20220224142533_fix_index_on_reported_at_to_ping_thing.rb
@@ -1,0 +1,6 @@
+class FixIndexOnReportedAtToPingThing < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :ping_things, :reported_at
+    add_index :ping_things, [:reported_at, :network]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_17_092117) do
+ActiveRecord::Schema.define(version: 2022_02_24_142533) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -228,7 +228,7 @@ ActiveRecord::Schema.define(version: 2022_02_17_092117) do
     t.datetime "reported_at"
     t.index ["created_at", "network", "transaction_type"], name: "index_ping_things_on_created_at_and_network_and_transaction_type"
     t.index ["created_at", "network", "user_id"], name: "index_ping_things_on_created_at_and_network_and_user_id"
-    t.index ["reported_at"], name: "index_ping_things_on_reported_at"
+    t.index ["reported_at", "network"], name: "index_ping_things_on_reported_at_and_network"
     t.index ["user_id"], name: "index_ping_things_on_user_id"
   end
 
@@ -358,17 +358,17 @@ ActiveRecord::Schema.define(version: 2022_02_17_092117) do
     t.string "network"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.float "manager_fee"
     t.string "ticker"
+    t.float "manager_fee"
     t.float "average_validators_commission"
     t.float "average_delinquent"
     t.float "average_skipped_slots"
     t.float "average_uptime"
     t.integer "average_lifetime"
     t.float "average_score"
+    t.float "average_apy"
     t.float "withdrawal_fee"
     t.float "deposit_fee"
-    t.float "average_apy"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/controllers/api/v1/ping_thing_controller_test.rb
+++ b/test/controllers/api/v1/ping_thing_controller_test.rb
@@ -101,7 +101,7 @@ class PingThingControllerTest < ActionDispatch::IntegrationTest
     signature = "5zxrAiJcBkAHpDtY4d3hf8YVgKjENpjUUEYYYH2cCbRozo8BiyTe6c7WtBqp6Rw2bkz7b5Vxkbi9avR7BV9J1a6s"
     
     assert_equal 1, json.size
-    assert_equal 9, json_record.size
+    assert_equal 10, json_record.size
 
     assert_equal "Mango",                         json_record["application"]
     assert_equal "processed",                     json_record["commitment_level"]

--- a/test/factories/ping_things.rb
+++ b/test/factories/ping_things.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     signature { "5zxrAiJcBkAHpDtY4d3hf8YVgKjENpjUUEYYYH2cCbRozo8BiyTe6c7WtBqp6Rw2bkz7b5Vxkbi9avR7BV9J1a6s" }
     success { true }
     transaction_type { "transfer" }
+    reported_at { Time.now }
     user
 
     trait :processed do


### PR DESCRIPTION
#### What's this PR do?
- Uses reported_at instead of created_at

#### How should this be manually tested?
- Review in browser under localhost:3000/ping-thing or on staging
- Try fetching more than one ping by API and confirm that they're sorted by reported_at
eg. pull by ```curl -H "Token: YOUR-KEY" 'https://stage.validators.app/api/v1/ping-thing/mainnet?limit=5```
and compare results with: https://stage.validators.app/ping-thing

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/181341014)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
