### PR TITLE
182012799 fix query on validator details

### DIFF
--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -74,10 +74,12 @@ class ValidatorsController < ApplicationController
     .limit(@history_limit)
 
     # Grab the distances to show on the chart
-    @root_blocks = @val_histories.map(&:root_distance).compact
+    #@root_blocks = @val_histories.map(&:root_distance).compact
+    @root_blocks = @validator.validator_histories.last(@history_limit).pluck(:root_distance)
 
     # Grab the distances to show on the chart
-    @vote_blocks = @val_histories.map(&:vote_distance).compact
+    #@vote_blocks = @val_histories.map(&:vote_distance).compact
+    @vote_blocks = @validator.validator_histories.last(@history_limit).pluck(:vote_distance)
 
     @commission_histories = CommissionHistoryQuery.new(
       network: params[:network]

--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -71,15 +71,13 @@ class ValidatorsController < ApplicationController
       time_from,
       time_to
     ).order(created_at: :asc)
-    .limit(@history_limit)
+    .last(@history_limit)
 
     # Grab the distances to show on the chart
-    #@root_blocks = @val_histories.map(&:root_distance).compact
-    @root_blocks = @validator.validator_histories.last(@history_limit).pluck(:root_distance)
+    @root_blocks = @val_histories.map(&:root_distance).compact
 
     # Grab the distances to show on the chart
-    #@vote_blocks = @val_histories.map(&:vote_distance).compact
-    @vote_blocks = @validator.validator_histories.last(@history_limit).pluck(:vote_distance)
+    @vote_blocks = @val_histories.map(&:vote_distance).compact
 
     @commission_histories = CommissionHistoryQuery.new(
       network: params[:network]


### PR DESCRIPTION
#### What's this PR do?
- Fixes query that takes wrong batch of validator histories for charts

#### How should this be manually tested?
- Review validator details pages and confirm that charts are fixed now, eg. https://stage.validators.app/validators/1aine15iEqZxYySNwcHtQFt4Sgc75cbEi9wks8YgNCa?locale=en&network=mainnet&order=&refresh=
  vs: https://www.validators.app/validators/1aine15iEqZxYySNwcHtQFt4Sgc75cbEi9wks8YgNCa?locale=en&network=mainnet&order=&refresh=
- Confirm that query is still quick
-
#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/182012799)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
