### PR TITLE
182297936-update-max-in-ping-thing-charts

### DIFF
--- a/app/javascript/packs/ping_thing/bubble_chart.js
+++ b/app/javascript/packs/ping_thing/bubble_chart.js
@@ -65,7 +65,6 @@ export default {
                         display: true,
                         ticks: {
                             min: 0,
-                            max: 60000,
                             padding: 10,
                             callback: function(value, index, values) {
                                 return value.toLocaleString('en-US')

--- a/app/javascript/packs/ping_thing/ping_thing_header.vue
+++ b/app/javascript/packs/ping_thing/ping_thing_header.vue
@@ -17,9 +17,5 @@
       applications. Please contact me at <a href="https://twitter.com/ValidatorsApp" target="_blank">@ValidatorsApp</a>
       on Twitter. -- @brianlong
     </p>
-    <p>
-      NOTES: We use a 60-second timeout threshold for the pings. On the chart and table below, a value of 60,000
-      milliseconds means that the operation failed or took longer than 60 seconds to complete.
-    </p>
   </section>
 </template>

--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -94,7 +94,6 @@ export default {
                         gridLines: { display: false },
                         ticks: {
                             min: 0,
-                            max: 60000,
                             padding: 10,
                             callback: function(value, index, values) {
                                 return value.toLocaleString('en-US')


### PR DESCRIPTION
#### What's this PR do?
- remove 60 sec limit on ping thing charts

#### How should this be manually tested?
- create ping thing with response_time greater than 60 sec and see if it's properly displayed on chart

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/182297936)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
