### PR TITLE
182619709_review_deactivation_script

### DIFF
--- a/app/services/validator_check_active_service.rb
+++ b/app/services/validator_check_active_service.rb
@@ -31,8 +31,9 @@ class ValidatorCheckActiveService
   private
 
   def should_be_destroyed?(validator)
-    if !validator.validator_histories.where("created_at > ?", @delinquent_time.ago).exists? && \
-       validator.validator_histories.where("created_at < ?", @delinquent_time.ago).exists?
+    if validator.validator_histories.blank? || \
+       (!validator.validator_histories.where("created_at > ?", @delinquent_time.ago).exists? && \
+        validator.validator_histories.where("created_at < ?", @delinquent_time.ago).exists?)
       return true
     end
 


### PR DESCRIPTION
#### What's this PR do?
- If validator does not have validator history mark it inactive and destroyed

#### How should this be manually tested?
- Run tests
- Create local validator with `is_active: true` and `is_destroyed: false`, run `ValidatorCheckActiveService.new.update_validator_activity` - it should set `is_active` to false and `is_destroyed` to true

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/182619709)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
