### PR TITLE
add always_update option to VoteAccountDetailsService

### DIFF
--- a/app/services/gatherers/vote_account_details_service.rb
+++ b/app/services/gatherers/vote_account_details_service.rb
@@ -6,7 +6,8 @@ module Gatherers
   class VoteAccountDetailsService
     include SolanaLogic
 
-    def initialize(network:, config_urls:)
+    def initialize(network:, config_urls:, always_update: false)
+      @always_update = always_update
       @network = network
       @config_urls = config_urls
       @range_start = VoteAccount.where(network: @network).order(id: :asc).first.id
@@ -26,7 +27,7 @@ module Gatherers
           next
         end
 
-        next if should_omit_update?(vacc, vote_account_details)
+        next if !@always_update && should_omit_update?(vacc, vote_account_details)
 
         if vacc.update(
             validator_identity: vote_account_details["validatorIdentity"],

--- a/dev/gather_vote_account_details_force_update.rb
+++ b/dev/gather_vote_account_details_force_update.rb
@@ -11,7 +11,7 @@ end
 %w[mainnet testnet].each do |network|
   puts "getting #{network} validators"
   puts "----------------------------"
-  config_urls = if network == 'testnet'
+  config_urls = if network == "testnet"
     Rails.application.credentials.solana[:testnet_urls]
   else
     Rails.application.credentials.solana[:mainnet_urls]

--- a/dev/gather_vote_account_details_force_update.rb
+++ b/dev/gather_vote_account_details_force_update.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+puts "stopping gather_vote_account_details.service"
+begin
+  `systemctl --user stop gather_vote_account_details.service`
+  puts "done"
+rescue Errno::ENOENT
+  puts "process not found"
+end
+
+%w[mainnet testnet].each do |network|
+  puts "getting #{network} validators"
+  puts "----------------------------"
+  config_urls = if network == 'testnet'
+    Rails.application.credentials.solana[:testnet_urls]
+  else
+    Rails.application.credentials.solana[:mainnet_urls]
+  end
+
+  Gatherers::VoteAccountDetailsService.new(
+    network: network,
+    config_urls: config_urls,
+    always_update: true
+  ).call
+end
+
+puts "starting gather_vote_account_details.service"
+begin
+  `systemctl --user start gather_vote_account_details.service`
+  puts "done"
+rescue Errno::ENOENT
+  puts "process not found"
+end


### PR DESCRIPTION
#### What's this PR do?
- determine why some validators does not have authorized_withdrawer_score updated
- add always_update flag to the VoteAccountDetailsService so it can be run manually and update score for each validator

#### How should this be manually tested?
- run dev/gather_vote_account_details_force_update.rb
- run tests

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/182809739)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
