### PR TITLE
183298708 add slot latency to pt stats

### DIFF
--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -148,9 +148,9 @@ export default {
                             callbacks: {
                                 label: function(tooltipItem) {
                                     if (tooltipItem.datasetIndex == 0) {
-                                        var min = tooltipItem.raw[1] ? tooltipItem.raw[1].toLocaleString('en-US') : null;
-                                        var max = tooltipItem.raw[0] ? tooltipItem.raw[0].toLocaleString('en-US') : null;
-                                        var slot_lat = tooltipItem.raw[2] ? tooltipItem.raw[2].toLocaleString('en-US') : null;
+                                        var min = tooltipItem.raw[1] ? tooltipItem.raw[1].toLocaleString('en-US') : "-";
+                                        var max = tooltipItem.raw[0] ? tooltipItem.raw[0].toLocaleString('en-US') : "-";
+                                        var slot_lat = tooltipItem.raw[2] ? tooltipItem.raw[2].toLocaleString('en-US') : "-";
 
                                         return "Min: " + min + " ms, Max: " + max + " ms, Average_slot_latency: " + slot_lat + " slots";
                                     } else {

--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -64,7 +64,10 @@ export default {
     update_chart: function(){
         if( !this.ping_thing_stats.length == 0 ){
             var line_data = this.ping_thing_stats.map( (vector_element, index) => (vector_element['median']) )
-            var variation_data = this.ping_thing_stats.map( (vector_element, index) => ([vector_element['max'], vector_element['min']]) )
+            var variation_data = this.ping_thing_stats.map( (vector_element, index) => (
+                [vector_element['max'], vector_element['min'], vector_element['average_slot_latency']]
+            ))
+            console.log(this.ping_thing_stats)
             var labels = this.ping_thing_stats.map( (vector_element) => (
                 moment(new Date(vector_element["time_from"])).utc().format('HH:mm')
             ))
@@ -146,7 +149,9 @@ export default {
                             callbacks: {
                                 label: function(tooltipItem) {
                                     if (tooltipItem.datasetIndex == 0) {
-                                        return "Min: " + tooltipItem.raw[1].toLocaleString('en-US') + " ms,  Max: " + tooltipItem.raw[0].toLocaleString('en-US') + " ms";
+                                        return "Min: " + tooltipItem.raw[1].toLocaleString('en-US') + " ms,  \
+                                                Max: " + tooltipItem.raw[0].toLocaleString('en-US') + " ms, \
+                                                Average_slot_latency: " + tooltipItem.raw[2].toLocaleString('en-US') + " slots";
                                     } else {
                                         return "Median: " + tooltipItem.formattedValue.toLocaleString('en-US') + " ms";
                                     }

--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -152,7 +152,7 @@ export default {
                                         var max = tooltipItem.raw[0] ? tooltipItem.raw[0].toLocaleString('en-US') : "-";
                                         var slot_lat = tooltipItem.raw[2] ? tooltipItem.raw[2].toLocaleString('en-US') : "-";
 
-                                        return "Min: " + min + " ms, Max: " + max + " ms, Average_slot_latency: " + slot_lat + " slots";
+                                        return ["Min: " + min + " ms, Max: " + max + " ms", "Average_slot_latency: " + slot_lat + " slots"];
                                     } else {
                                         return "Median: " + tooltipItem.formattedValue.toLocaleString('en-US') + " ms";
                                     }

--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -67,7 +67,6 @@ export default {
             var variation_data = this.ping_thing_stats.map( (vector_element, index) => (
                 [vector_element['max'], vector_element['min'], vector_element['average_slot_latency']]
             ))
-            console.log(this.ping_thing_stats)
             var labels = this.ping_thing_stats.map( (vector_element) => (
                 moment(new Date(vector_element["time_from"])).utc().format('HH:mm')
             ))
@@ -149,9 +148,11 @@ export default {
                             callbacks: {
                                 label: function(tooltipItem) {
                                     if (tooltipItem.datasetIndex == 0) {
-                                        return "Min: " + tooltipItem.raw[1].toLocaleString('en-US') + " ms,  \
-                                                Max: " + tooltipItem.raw[0].toLocaleString('en-US') + " ms, \
-                                                Average_slot_latency: " + tooltipItem.raw[2].toLocaleString('en-US') + " slots";
+                                        var min = tooltipItem.raw[1] ? tooltipItem.raw[1].toLocaleString('en-US') : null;
+                                        var max = tooltipItem.raw[0] ? tooltipItem.raw[0].toLocaleString('en-US') : null;
+                                        var slot_lat = tooltipItem.raw[2] ? tooltipItem.raw[2].toLocaleString('en-US') : null;
+
+                                        return "Min: " + min + " ms, Max: " + max + " ms, Average_slot_latency: " + slot_lat + " slots";
                                     } else {
                                         return "Median: " + tooltipItem.formattedValue.toLocaleString('en-US') + " ms";
                                     }

--- a/app/models/ping_thing_stat.rb
+++ b/app/models/ping_thing_stat.rb
@@ -4,16 +4,17 @@
 #
 # Table name: ping_thing_stats
 #
-#  id             :bigint           not null, primary key
-#  interval       :integer
-#  max            :float(24)
-#  median         :float(24)
-#  min            :float(24)
-#  network        :string(191)
-#  num_of_records :integer
-#  time_from      :datetime
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                   :bigint           not null, primary key
+#  average_slot_latency :integer
+#  interval             :integer
+#  max                  :float(24)
+#  median               :float(24)
+#  min                  :float(24)
+#  network              :string(191)
+#  num_of_records       :integer
+#  time_from            :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #
 # Indexes
 #

--- a/app/models/ping_thing_stat.rb
+++ b/app/models/ping_thing_stat.rb
@@ -28,7 +28,8 @@ class PingThingStat < ApplicationRecord
     :min,
     :network,
     :num_of_records,
-    :time_from
+    :time_from,
+    :average_slot_latency
   ].freeze
 
   INTERVALS = [1, 3, 12, 24].freeze #minutes

--- a/app/services/create_ping_thing_stats_service.rb
+++ b/app/services/create_ping_thing_stats_service.rb
@@ -21,7 +21,8 @@ class CreatePingThingStatsService
           min: resp_times.min,
           max: resp_times.max,
           time_from: @time_to - interval.minutes,
-          num_of_records: ping_things.count
+          num_of_records: ping_things.count,
+          average_slot_latency: ping_things.map{ |pt| pt.slot_landed - pt.slot_sent }.average
         )
       end
     end

--- a/app/services/create_ping_thing_stats_service.rb
+++ b/app/services/create_ping_thing_stats_service.rb
@@ -22,7 +22,7 @@ class CreatePingThingStatsService
           max: resp_times.max,
           time_from: @time_to - interval.minutes,
           num_of_records: ping_things.count,
-          average_slot_latency: ping_things.map{ |pt| pt.slot_landed - pt.slot_sent }.average
+          average_slot_latency: ping_things.map{ |pt| pt.slot_landed ? pt.slot_landed - pt.slot_sent : nil }.compact.average
         )
       end
     end

--- a/db/migrate/20220919072658_add_slot_latency_to_ping_thing_stats.rb
+++ b/db/migrate/20220919072658_add_slot_latency_to_ping_thing_stats.rb
@@ -1,0 +1,5 @@
+class AddSlotLatencyToPingThingStats < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ping_thing_stats, :average_slot_latency, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_16_065710) do
+ActiveRecord::Schema.define(version: 2022_09_19_072658) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -259,6 +259,7 @@ ActiveRecord::Schema.define(version: 2022_09_16_065710) do
     t.datetime "time_from"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "average_slot_latency"
     t.index ["network", "interval"], name: "index_ping_thing_stats_on_network_and_interval"
   end
 

--- a/dev/create_test_ping_things.rb
+++ b/dev/create_test_ping_things.rb
@@ -10,6 +10,7 @@ counts = [{count: 5000, min_time: 700,   max_time: 4500},
 
 counts.each do |loop|
   loop[:count].times do |n|
+    slot_sent = rand(10_000_000..100_000_000)
     p = PingThing.create(
       user_id: 1,
       amount: 1, signature: "5zxrAiJcBkAHpDtY4d3hf8YVgKjsdfsasdfasdfasdfasdfasdfdflkhasdlkhflkasjdhf6Rw#{n}",
@@ -19,7 +20,9 @@ counts.each do |loop|
       commitment_level: "confirmed",
       success: true,
       application: "web3",
-      reported_at: rand(24.hours.ago..Time.now)
+      reported_at: rand(24.hours.ago..Time.now),
+      slot_sent: slot_sent,
+      slot_landed: slot_sent + rand(100..10_000)
     )
     if p.valid?
       puts p.inspect

--- a/test/services/create_ping_thing_stats_service_test.rb
+++ b/test/services/create_ping_thing_stats_service_test.rb
@@ -6,14 +6,15 @@ class CreatePingThingStatsServiceTest < ActiveSupport::TestCase
   setup do
     @network = "testnet"
     @pts_Service = CreatePingThingStatsService.new(network: @network)
-    usr = create(:user)
+    @usr = create(:user)
 
     25.times do |n|
       create(
         :ping_thing,
         network: @network,
-        user: usr,
-        reported_at: DateTime.now - (n.minutes + 5.seconds)
+        user: @usr,
+        response_time: n,
+        reported_at: DateTime.now - (n.minutes + 5.seconds),
       )
     end
   end
@@ -50,5 +51,45 @@ class CreatePingThingStatsServiceTest < ActiveSupport::TestCase
     assert_equal 8, PingThingStat.where(interval: PingThingStat::INTERVALS[1]).count
     assert_equal 2, PingThingStat.where(interval: PingThingStat::INTERVALS[2]).count
     assert_equal 1, PingThingStat.where(interval: PingThingStat::INTERVALS[3]).count
+  end
+
+  test "CreatePingThingStatsService creates records with correct fields" do
+    begin_minutes_ago = 1
+    begin_minutes_ago.times.each do |n|
+      CreatePingThingStatsService.new(time_to: (begin_minutes_ago - n).minutes.ago, network: @network).call
+    end
+    
+    stat = PingThingStat.where(interval: PingThingStat::INTERVALS[3]).last
+    assert_equal 24, stat.interval
+    assert_equal 1, stat.min
+    assert_equal 24, stat.max
+    assert_equal 13, stat.median
+    assert_equal 24, stat.num_of_records
+    assert_equal @network, stat.network
+    assert_equal 2, stat.average_slot_latency
+  end
+
+  test "CreatePingThingStatsService calculates real average of slot_latency" do
+    slot_latency = 4
+
+    25.times do |n|
+      create(
+        :ping_thing,
+        network: "mainnet",
+        user: @usr,
+        response_time: n,
+        reported_at: DateTime.now - (n.minutes + 5.seconds),
+        slot_sent: n,
+        slot_landed: n + slot_latency
+      )
+    end
+
+    begin_minutes_ago = 1
+    begin_minutes_ago.times.each do |n|
+      CreatePingThingStatsService.new(time_to: (begin_minutes_ago - n).minutes.ago, network: "mainnet").call
+    end
+    
+    stat = PingThingStat.where(interval: PingThingStat::INTERVALS[3]).last
+    assert_equal slot_latency, stat.average_slot_latency
   end
 end

--- a/test/services/create_ping_thing_stats_service_test.rb
+++ b/test/services/create_ping_thing_stats_service_test.rb
@@ -53,6 +53,14 @@ class CreatePingThingStatsServiceTest < ActiveSupport::TestCase
     assert_equal 1, PingThingStat.where(interval: PingThingStat::INTERVALS[3]).count
   end
 
+  test "CreatePingThingStatsService does not return error when slot fields are empty" do
+    PingThing.update_all(slot_sent: nil, slot_landed: nil)
+    
+    assert_nothing_raised do
+      CreatePingThingStatsService.new(time_to: 1.minutes.ago, network: @network).call
+    end
+  end
+
   test "CreatePingThingStatsService creates records with correct fields" do
     begin_minutes_ago = 1
     begin_minutes_ago.times.each do |n|


### PR DESCRIPTION
#### What's this PR do?
- add slot latency to ping_thing_stats and display it in the chart

#### How should this be manually tested?
- run migrations
- run tests
- populate db with test data
- check if ping thing stats have average_slot_latency populated
- check if additional data is visible on the chart (as in pt story)

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/183298708

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [Y] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
