### PR TITLE
183323571_remove_validators_ips_without_val_or_gossip_node_assigned

### DIFF
--- a/script/validator_ips/remove_without_validator_or_gossip_node.rb
+++ b/script/validator_ips/remove_without_validator_or_gossip_node.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 #
-# RAILS_ENV=production bundle exec rails r script/validator_ips/remove_without_validator_or_gossip_node.rb
+# RAILS_ENV=production bundle exec rails r script/validator_ips/remove_without_validator_or_gossip_node.rb [yes]
 
 require_relative '../../config/environment'
 
-ValidatorIp.where.missing(:validator, :gossip_node).destroy_all
+run_destroy = ARGV[0]
 
+puts "Validator Ips before removal: #{ValidatorIp.count}"
+validator_ips_without_validator_and_gossip_node = ValidatorIp.where.missing(:validator, :gossip_node)
+puts "Validator Ips to remove: #{validator_ips_without_validator_and_gossip_node.size}"
+
+if run_destroy == "yes"
+  validator_ips_without_validator_and_gossip_node.destroy_all
+  puts "Validator Ips after removal: #{ValidatorIp.count}"
+end

--- a/script/validator_ips/remove_without_validator_or_gossip_node.rb
+++ b/script/validator_ips/remove_without_validator_or_gossip_node.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+#
+# RAILS_ENV=production bundle exec rails r script/validator_ips/remove_without_validator_or_gossip_node.rb
+
+require_relative '../../config/environment'
+
+ValidatorIp.where.missing(:validator, :gossip_node).destroy_all
+


### PR DESCRIPTION
Add script for removing orphaned validator_ips (no validator or gossip_node)

#### What's this PR do?
- Removes orphaned validator ips

#### How should this be manually tested?
- Run script

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183323571)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
