### PR TITLE
183338373 average latency in recent stats

### DIFF
--- a/app/javascript/packs/ping_thing/stats_bar.vue
+++ b/app/javascript/packs/ping_thing/stats_bar.vue
@@ -15,7 +15,7 @@
               Entries&nbsp;
             </span>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
+          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min&nbsp;
@@ -27,10 +27,16 @@
               Median&nbsp;
             </span>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 text-md-center d-none d-lg-block">
+          <div class="col-lg-1 col-md-6 px-md-0 text-md-center d-none d-lg-block">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90&nbsp;
+            </span>
+          </div>
+          <div class="col-lg-2 col-md-6 px-md-0 text-md-center d-none d-lg-block">
+            <span class="stat-title-4">
+              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
+              Avg Slot Latency&nbsp;
             </span>
           </div>
         </div>
@@ -47,7 +53,7 @@
             </span>
             <strong class="text-success">{{ last_5_mins["num_of_records"] ? last_5_mins["num_of_records"].toLocaleString() : '0' }}</strong>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min:&nbsp;
@@ -61,12 +67,19 @@
             </span>
             <strong class="text-success">{{ last_5_mins["median"] ? last_5_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 text-md-center">
+          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
              <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90:&nbsp;
             </span>
             <strong class="text-success">{{ last_5_mins["p90"] ? last_5_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+          </div>
+          <div class="col-lg-2 col-md-6 offset-md-3 offset-lg-0 px-md-0 text-md-center">
+            <span class="stat-title-4 d-lg-none">
+              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
+              Average slot latency:&nbsp;
+            </span>
+            <strong class="text-success">{{ last_5_mins["average_slot_latency"] ? last_5_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
           </div>
         </div>
 
@@ -82,7 +95,7 @@
             </span>
             <strong class="text-success">{{ last_60_mins["num_of_records"] ? last_60_mins["num_of_records"].toLocaleString() : '0' }}</strong>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min:&nbsp;
@@ -96,12 +109,19 @@
             </span>
             <strong class="text-success">{{ last_60_mins["median"] ? last_60_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
           </div>
-          <div class="col-lg-2 col-md-6 px-md-0 text-md-center">
+          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90:&nbsp;
             </span>
             <strong class="text-success">{{ last_60_mins["p90"] ? last_60_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+          </div>
+          <div class="col-lg-2 col-md-6 offset-md-3 offset-lg-0 px-md-0 text-md-center">
+            <span class="stat-title-4 d-lg-none">
+              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
+              Average slot latency:&nbsp;
+            </span>
+            <strong class="text-success">{{ last_60_mins["average_slot_latency"] ? last_60_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
           </div>
         </div>
       </div>

--- a/app/javascript/packs/ping_thing/stats_bar.vue
+++ b/app/javascript/packs/ping_thing/stats_bar.vue
@@ -6,7 +6,7 @@
           <a class="small" :href="pt_url">See details on the Ping Thing page</a>
         </div>
         <div class="row px-xl-4 ping-thing-stats-header">
-          <div class="col-lg-2 offset-lg-1 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-none d-lg-block">Stats from&nbsp;</span>
           </div>
           <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
@@ -15,7 +15,7 @@
               Entries&nbsp;
             </span>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
+          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min&nbsp;
@@ -27,7 +27,7 @@
               Median&nbsp;
             </span>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 text-md-center d-none d-lg-block">
+          <div class="col-lg-2 col-md-6 px-md-0 text-md-center d-none d-lg-block">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90&nbsp;
@@ -42,7 +42,7 @@
         </div>
 
         <div class="row px-xl-4 mt-2 text-center">
-          <div class="col-lg-2 offset-lg-1 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-3 d-lg-none">5 min stats&nbsp;</span>
             <span class="stat-title-4 d-none d-lg-block">5 min&nbsp;</span>
           </div>
@@ -53,7 +53,7 @@
             </span>
             <strong class="text-success">{{ last_5_mins["num_of_records"] ? last_5_mins["num_of_records"].toLocaleString() : '0' }}</strong>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min:&nbsp;
@@ -67,7 +67,7 @@
             </span>
             <strong class="text-success">{{ last_5_mins["median"] ? last_5_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
              <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90:&nbsp;
@@ -84,7 +84,7 @@
         </div>
 
         <div class="row px-xl-4 mt-2 text-center">
-          <div class="col-lg-2 offset-lg-1 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-3 d-lg-none">1 hour stats&nbsp;</span>
             <span class="stat-title-4 d-none d-lg-block">1 hour&nbsp;</span>
           </div>
@@ -95,7 +95,7 @@
             </span>
             <strong class="text-success">{{ last_60_mins["num_of_records"] ? last_60_mins["num_of_records"].toLocaleString() : '0' }}</strong>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
               Min:&nbsp;
@@ -109,7 +109,7 @@
             </span>
             <strong class="text-success">{{ last_60_mins["median"] ? last_60_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
           </div>
-          <div class="col-lg-1 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
               P90:&nbsp;

--- a/app/javascript/packs/ping_thing/stats_chart.js
+++ b/app/javascript/packs/ping_thing/stats_chart.js
@@ -152,7 +152,7 @@ export default {
                                         var max = tooltipItem.raw[0] ? tooltipItem.raw[0].toLocaleString('en-US') : "-";
                                         var slot_lat = tooltipItem.raw[2] ? tooltipItem.raw[2].toLocaleString('en-US') : "-";
 
-                                        return ["Min: " + min + " ms, Max: " + max + " ms", "Average_slot_latency: " + slot_lat + " slots"];
+                                        return ["Min: " + min + " ms, Max: " + max + " ms", "Average slot latency: " + slot_lat + " slots"];
                                     } else {
                                         return "Median: " + tooltipItem.formattedValue.toLocaleString('en-US') + " ms";
                                     }

--- a/app/models/ping_thing.rb
+++ b/app/models/ping_thing.rb
@@ -82,4 +82,8 @@ class PingThing < ApplicationRecord
     stats = PingThingStat.by_network(network).between_time_range(reported_at)
     stats.each(&:recalculate)
   end
+
+  def self.average_slot_latency
+    all.map{ |pt| pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil }.compact.average
+  end
 end

--- a/app/models/ping_thing_recent_stat.rb
+++ b/app/models/ping_thing_recent_stat.rb
@@ -4,16 +4,17 @@
 #
 # Table name: ping_thing_recent_stats
 #
-#  id             :bigint           not null, primary key
-#  interval       :integer
-#  max            :float(24)
-#  median         :float(24)
-#  min            :float(24)
-#  network        :string(191)
-#  num_of_records :integer
-#  p90            :float(24)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                   :bigint           not null, primary key
+#  average_slot_latency :float(24)
+#  interval             :integer
+#  max                  :float(24)
+#  median               :float(24)
+#  min                  :float(24)
+#  network              :string(191)
+#  num_of_records       :integer
+#  p90                  :float(24)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #
 # Indexes
 #

--- a/db/migrate/20220922145718_add_average_slot_latency_to_ping_thing_recent_stats.rb
+++ b/db/migrate/20220922145718_add_average_slot_latency_to_ping_thing_recent_stats.rb
@@ -1,0 +1,5 @@
+class AddAverageSlotLatencyToPingThingRecentStats < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ping_thing_recent_stats, :average_slot_latency, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_19_072658) do
+ActiveRecord::Schema.define(version: 2022_09_22_145718) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 2022_09_19_072658) do
     t.string "network"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "average_slot_latency"
     t.index ["network", "interval"], name: "index_ping_thing_recent_stats_on_network_and_interval"
   end
 

--- a/dev/create_test_ping_things.rb
+++ b/dev/create_test_ping_things.rb
@@ -13,7 +13,9 @@ counts.each do |loop|
     slot_sent = rand(10_000_000..100_000_000)
     p = PingThing.create(
       user_id: 1,
-      amount: 1, signature: "5zxrAiJcBkAHpDtY4d3hf8YVgKjsdfsasdfasdfasdfasdfasdfdflkhasdlkhflkasjdhf6Rw#{n}",
+      user_id: User.first.id,
+      amount: 1, 
+      signature: "5zxrAiJcBkAHpDtY4d3hf8YVgKjsdfsasdfasdfasdfasdfasdfdflkhasdlkhflkasjdhf6Rw#{n}",
       response_time: rand(loop[:min_time]..loop[:max_time]),
       transaction_type: "transfer",
       network: "mainnet",

--- a/dev/create_test_ping_things.rb
+++ b/dev/create_test_ping_things.rb
@@ -16,7 +16,7 @@ counts.each do |loop|
       amount: 1, signature: "5zxrAiJcBkAHpDtY4d3hf8YVgKjsdfsasdfasdfasdfasdfasdfdflkhasdlkhflkasjdhf6Rw#{n}",
       response_time: rand(loop[:min_time]..loop[:max_time]),
       transaction_type: "transfer",
-      network: "testnet",
+      network: "mainnet",
       commitment_level: "confirmed",
       success: true,
       application: "web3",

--- a/test/models/ping_thing_recent_stat_test.rb
+++ b/test/models/ping_thing_recent_stat_test.rb
@@ -75,4 +75,24 @@ class PingThingRecentStatTest < ActiveSupport::TestCase
     skip
     # TODO
   end
+
+  test "#recalculate_stats counts average of slot latency" do
+    slot_latency = 5
+    5.times do |time|
+      create(
+        :ping_thing,
+        :testnet,
+        reported_at: rand(50.minutes.ago..Time.now),
+        slot_sent: time,
+        slot_landed: time + slot_latency
+      )
+    end
+
+    ping_stat = create(:ping_thing_recent_stat, interval: 60)
+
+    ping_stat.recalculate_stats
+    ping_stat.reload
+
+    assert_equal slot_latency, ping_stat.average_slot_latency
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
- Include average slot latency in recent stats table for 5min and 60 min

#### How should this be manually tested?
- run migrations
- run tests
- `rails r dev/create_test_ping_things.rb`
- run worker PingThingRecentStatsWorker
- look at the table with pt stats on the landing page and in /ping-thing site and confirm that everything looks ok

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183338373)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [Y] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
