### PR TITLE
183374980 fix recent stats table display

### DIFF
--- a/app/javascript/packs/ping_thing/stats_bar.vue
+++ b/app/javascript/packs/ping_thing/stats_bar.vue
@@ -6,69 +6,69 @@
         <a class="small" :href="pt_url">See details on the Ping Thing page</a>
       </div>
 
-      <div class="row d-none d-lg-flex">
-        <div class="col-lg-2 text-md-center mb-2">
+      <div class="row d-none d-lg-flex text-lg-center">
+        <div class="col-lg-2 mb-2">
           <span class="stat-title-4">Stats</span>
         </div>
-        <div class="col-lg-2 text-md-center mb-2">
+        <div class="col-lg-2 mb-2">
             <span class="stat-title-4">
               <i class="fas fa-calculator text-success me-1"></i> Entries
             </span>
         </div>
-        <div class="col-md-2 text-md-center mb-2">
+        <div class="col-md-2 mb-2">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min
             </span>
         </div>
-        <div class="col-lg-2 text-md-center mb-2">
+        <div class="col-lg-2 mb-2">
             <span class="stat-title-4">
               <i class="fas fa-divide text-success me-1"></i> Median
             </span>
         </div>
-        <div class="col-lg-2 text-md-center mb-2">
+        <div class="col-lg-2 mb-2">
             <span class="stat-title-4">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90
             </span>
         </div>
-        <div class="col-lg-2 text-md-center mb-2">
+        <div class="col-lg-2 mb-2">
             <span class="stat-title-4">
               <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency
             </span>
         </div>
       </div>
 
-      <div class="row">
+      <div class="row text-lg-center">
         <div class="col-sm-6 col-lg-12">
           <div class="row">
-            <div class="col-lg-2 text-md-center mb-3 mb-lg-2">
+            <div class="col-lg-2 mb-3 mb-lg-2">
               <span class="stat-title-3 d-lg-none">5 min stats</span>
               <span class="stat-title-4 d-none d-lg-block">5 min</span>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-calculator text-success me-1"></i> Entries:&nbsp;
             </span>
               <strong class="text-success">{{ last_5_mins["num_of_records"] ? last_5_mins["num_of_records"].toLocaleString() : '0' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min:&nbsp;
             </span>
               <strong class="text-success">{{ last_5_mins["min"] ? last_5_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-divide text-success me-1"></i> Median:&nbsp;
             </span>
               <strong class="text-success">{{ last_5_mins["median"] ? last_5_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
              <span class="stat-title-4 d-lg-none">
               <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90:&nbsp;
             </span>
               <strong class="text-success">{{ last_5_mins["p90"] ? last_5_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
             <span class="stat-title-4 d-lg-none">
               <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency:&nbsp;
             </span>
@@ -79,35 +79,35 @@
 
         <div class="col-sm-6 col-lg-12">
           <div class="row">
-            <div class="col-lg-2 text-md-center my-3 mb-lg-2 mt-sm-0">
+            <div class="col-lg-2 my-3 mb-lg-2 mt-sm-0">
               <span class="stat-title-3 d-lg-none">1 hour stats</span>
               <span class="stat-title-4 d-none d-lg-block">1 hour</span>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
                 <span class="stat-title-4 d-lg-none">
                   <i class="fas fa-calculator text-success me-1"></i> Entries:&nbsp;
                 </span>
               <strong class="text-success">{{ last_60_mins["num_of_records"] ? last_60_mins["num_of_records"].toLocaleString() : '0' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
                 <span class="stat-title-4 d-lg-none">
                   <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min:&nbsp;
                 </span>
               <strong class="text-success">{{ last_60_mins["min"] ? last_60_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
                 <span class="stat-title-4 d-lg-none">
                   <i class="fas fa-divide text-success me-1"></i> Median:&nbsp;
                 </span>
               <strong class="text-success">{{ last_60_mins["median"] ? last_60_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
                 <span class="stat-title-4 d-lg-none">
                   <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90:&nbsp;
                 </span>
               <strong class="text-success">{{ last_60_mins["p90"] ? last_60_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
             </div>
-            <div class="col-lg-2 text-md-center mb-2">
+            <div class="col-lg-2 mb-2">
                 <span class="stat-title-4 d-lg-none">
                   <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency:&nbsp;
                 </span>

--- a/app/javascript/packs/ping_thing/stats_bar.vue
+++ b/app/javascript/packs/ping_thing/stats_bar.vue
@@ -1,131 +1,123 @@
 <template>
   <div class="card mb-4">
-      <div class="card-content">
-        <div class="card-heading" v-if="titleVisible" data-turbolinks="false">
-          <h2 class="h3 mb-2">Recent TX Confirmation Time Stats</h2>
-          <a class="small" :href="pt_url">See details on the Ping Thing page</a>
-        </div>
-        <div class="row px-xl-4 ping-thing-stats-header">
-          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-none d-lg-block">Stats from&nbsp;</span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
-            <span class="stat-title-4">
-              <i class="fas fa-calculator text-success me-2"></i>
-              Entries&nbsp;
-            </span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
-            <span class="stat-title-4">
-              <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
-              Min&nbsp;
-            </span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center d-none d-lg-block">
-            <span class="stat-title-4">
-              <i class="fas fa-divide text-success me-1"></i>
-              Median&nbsp;
-            </span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 text-md-center d-none d-lg-block">
-            <span class="stat-title-4">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              P90&nbsp;
-            </span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 text-md-center d-none d-lg-block">
-            <span class="stat-title-4">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              Avg Slot Latency&nbsp;
-            </span>
-          </div>
-        </div>
+    <div class="card-content">
+      <div class="card-heading" v-if="titleVisible" data-turbolinks="false">
+        <h2 class="h3 mb-2">Recent TX Confirmation Time Stats</h2>
+        <a class="small" :href="pt_url">See details on the Ping Thing page</a>
+      </div>
 
-        <div class="row px-xl-4 mt-2 text-center">
-          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-3 d-lg-none">5 min stats&nbsp;</span>
-            <span class="stat-title-4 d-none d-lg-block">5 min&nbsp;</span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-calculator text-success me-2"></i>
-              Entries:&nbsp;
+      <div class="row d-none d-lg-flex">
+        <div class="col-lg-2 text-md-center mb-2">
+          <span class="stat-title-4">Stats</span>
+        </div>
+        <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4">
+              <i class="fas fa-calculator text-success me-1"></i> Entries
             </span>
-            <strong class="text-success">{{ last_5_mins["num_of_records"] ? last_5_mins["num_of_records"].toLocaleString() : '0' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
-              Min:&nbsp;
+        </div>
+        <div class="col-md-2 text-md-center mb-2">
+            <span class="stat-title-4">
+              <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min
             </span>
-            <strong class="text-success">{{ last_5_mins["min"] ? last_5_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-divide text-success me-1"></i>
-              Median:&nbsp;
+        </div>
+        <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4">
+              <i class="fas fa-divide text-success me-1"></i> Median
             </span>
-            <strong class="text-success">{{ last_5_mins["median"] ? last_5_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
+        </div>
+        <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4">
+              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90
+            </span>
+        </div>
+        <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4">
+              <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency
+            </span>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-6 col-lg-12">
+          <div class="row">
+            <div class="col-lg-2 text-md-center mb-3 mb-lg-2">
+              <span class="stat-title-3 d-lg-none">5 min stats</span>
+              <span class="stat-title-4 d-none d-lg-block">5 min</span>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4 d-lg-none">
+              <i class="fas fa-calculator text-success me-1"></i> Entries:&nbsp;
+            </span>
+              <strong class="text-success">{{ last_5_mins["num_of_records"] ? last_5_mins["num_of_records"].toLocaleString() : '0' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4 d-lg-none">
+              <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min:&nbsp;
+            </span>
+              <strong class="text-success">{{ last_5_mins["min"] ? last_5_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+            <span class="stat-title-4 d-lg-none">
+              <i class="fas fa-divide text-success me-1"></i> Median:&nbsp;
+            </span>
+              <strong class="text-success">{{ last_5_mins["median"] ? last_5_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
              <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              P90:&nbsp;
+              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90:&nbsp;
             </span>
-            <strong class="text-success">{{ last_5_mins["p90"] ? last_5_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 offset-md-3 offset-lg-0 px-md-0 text-md-center">
+              <strong class="text-success">{{ last_5_mins["p90"] ? last_5_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
             <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              Average slot latency:&nbsp;
+              <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency:&nbsp;
             </span>
-            <strong class="text-success">{{ last_5_mins["average_slot_latency"] ? last_5_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
+              <strong class="text-success">{{ last_5_mins["average_slot_latency"] ? last_5_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
+            </div>
           </div>
         </div>
 
-        <div class="row px-xl-4 mt-2 text-center">
-          <div class="col-lg-2 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-3 d-lg-none">1 hour stats&nbsp;</span>
-            <span class="stat-title-4 d-none d-lg-block">1 hour&nbsp;</span>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-calculator text-success me-2"></i>
-              Entries:&nbsp;
-            </span>
-            <strong class="text-success">{{ last_60_mins["num_of_records"] ? last_60_mins["num_of_records"].toLocaleString() : '0' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-down text-success me-1"></i>
-              Min:&nbsp;
-            </span>
-            <strong class="text-success">{{ last_60_mins["min"] ? last_60_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-divide text-success me-1"></i>
-              Median:&nbsp;
-            </span>
-            <strong class="text-success">{{ last_60_mins["median"] ? last_60_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 px-md-0 mb-3 mb-lg-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              P90:&nbsp;
-            </span>
-            <strong class="text-success">{{ last_60_mins["p90"] ? last_60_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
-          </div>
-          <div class="col-lg-2 col-md-6 offset-md-3 offset-lg-0 px-md-0 text-md-center">
-            <span class="stat-title-4 d-lg-none">
-              <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i>
-              Average slot latency:&nbsp;
-            </span>
-            <strong class="text-success">{{ last_60_mins["average_slot_latency"] ? last_60_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
+        <div class="col-sm-6 col-lg-12">
+          <div class="row">
+            <div class="col-lg-2 text-md-center my-3 mb-lg-2 mt-sm-0">
+              <span class="stat-title-3 d-lg-none">1 hour stats</span>
+              <span class="stat-title-4 d-none d-lg-block">1 hour</span>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+                <span class="stat-title-4 d-lg-none">
+                  <i class="fas fa-calculator text-success me-1"></i> Entries:&nbsp;
+                </span>
+              <strong class="text-success">{{ last_60_mins["num_of_records"] ? last_60_mins["num_of_records"].toLocaleString() : '0' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+                <span class="stat-title-4 d-lg-none">
+                  <i class="fas fa-long-arrow-alt-down text-success me-1"></i> Min:&nbsp;
+                </span>
+              <strong class="text-success">{{ last_60_mins["min"] ? last_60_mins["min"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+                <span class="stat-title-4 d-lg-none">
+                  <i class="fas fa-divide text-success me-1"></i> Median:&nbsp;
+                </span>
+              <strong class="text-success">{{ last_60_mins["median"] ? last_60_mins["median"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+                <span class="stat-title-4 d-lg-none">
+                  <i class="fas fa-long-arrow-alt-up text-success me-1" aria-hidden="true"></i> P90:&nbsp;
+                </span>
+              <strong class="text-success">{{ last_60_mins["p90"] ? last_60_mins["p90"].toLocaleString() + ' ms' : 'N / A' }}</strong>
+            </div>
+            <div class="col-lg-2 text-md-center mb-2">
+                <span class="stat-title-4 d-lg-none">
+                  <i class="fas fa-clock text-success me-1" aria-hidden="true"></i> Latency:&nbsp;
+                </span>
+              <strong class="text-success">{{ last_60_mins["average_slot_latency"] ? last_60_mins["average_slot_latency"].toLocaleString() + ' slots' : 'N / A' }}</strong>
+            </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/app/views/public/api_documentation.html.erb
+++ b/app/views/public/api_documentation.html.erb
@@ -503,7 +503,8 @@
     "min"=>50.0,
     "network"=>"testnet",
     "num_of_records"=>10,
-    "time_from"=>"2022-04-21T13:41:00.000Z"
+    "time_from"=>"2022-04-21T13:41:00.000Z",
+    "average_slot_latency":2
   },
   ...
 ]


### PR DESCRIPTION
#### What's this PR do?
- Fixes stats table icon and layout

#### How should this be manually tested?
- Review in browser on home page 
(you can generate pings first, but it's not necessary:
`rails r dev/create_test_ping_things.rb` & `rails r script/one_time_scripts/back_fill_ping_thing_stats.rb` - sidekiq must be running)
- Test on desktop and mobile

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/183374980)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
