### PR TITLE
183370357 fix chart annotations

### DIFF
--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -86,12 +86,11 @@ table, .table {
   .chart {
     &-top-container {
       position: relative;
-      margin-left: 20px;
-      width: 90%;
+      margin-left: 25px;
+      width: 87%;
     }
     &-top-value {
       position: absolute;
-      width: 100%;
       font-size: 11px;
       color: #979797;
       margin-top: -13px;

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -208,7 +208,7 @@ table, .table {
           width: 26%;
         }
         @media(max-width: $screen-lg-max) {
-          width: 250px;
+          width: 220px;
         }
         &-row {
           display: flex;

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -84,18 +84,19 @@ table, .table {
   }
 
   .chart {
+    &-top-container {
+      position: relative;
+      margin-left: 20px;
+      width: 90%;
+    }
     &-top-value {
+      position: absolute;
       width: 100%;
-      padding-left: 5px;
       font-size: 11px;
       color: #979797;
-      margin-top: -15px;
-      margin-bottom: 5px;
+      margin-top: -13px;
       @media(max-width: $screen-md-max) {
-        margin-bottom: 15px;
-      }
-      @media(max-width: $screen-sm-max) {
-        margin-bottom: 10px;
+        display: none;
       }
     }
     &-link.active {

--- a/app/helpers/validators_helper.rb
+++ b/app/helpers/validators_helper.rb
@@ -15,6 +15,20 @@ module ValidatorsHelper
     [X_SCALE_MAX, count].min
   end
 
+  def max_value_position(vector)
+    max_value = vector.max
+    max_value_index = vector.index(max_value)
+    position = max_value_index.to_f / vector.size * 100
+    position = [position, 2].max
+    # set max position for large numbers
+    if max_value > 100_000
+      position = [position, 70].min
+    elsif max_value > 10_000
+      position = [position, 80].min
+    end
+    number_to_percentage(position, precision: 0)
+  end
+
   def display_avatar(validator)
     if validator&.avatar_url
       image_tag validator.avatar_url, class: 'img-circle mb-1'

--- a/app/javascript/packs/stake_accounts/charts/root_distance_chart.js
+++ b/app/javascript/packs/stake_accounts/charts/root_distance_chart.js
@@ -24,6 +24,7 @@ export default {
       }
       return chart_vars.chart_lightgrey
     },
+
     chart_fill_color(val) {
       if (val == 2) {
         return chart_vars.chart_green_t
@@ -34,9 +35,13 @@ export default {
     },
   },
   data() {
-    var root_distance_vl = Math.min.apply(Math, [60, this.validator['root_distance_history'].length])
-    var root_distance_vector = this.validator['root_distance_history'].slice(Math.max(this.validator['root_distance_history'].length - root_distance_vl, 0))
+    var root_distance_vl = Math.min.apply(Math, [60, this.validator['root_distance_history'].length]);
+    var root_distance_vector = this.validator['root_distance_history'].slice(Math.max(this.validator['root_distance_history'].length - root_distance_vl, 0));
+    var max_value = Math.max.apply(Math, root_distance_vector);
+    var max_value_position = this.$parent.max_value_position(root_distance_vector);
     return {
+      max_value: max_value,
+      max_value_position: max_value_position,
       y_root_distance_max: 20,
       root_distance_chart: {
         vl: root_distance_vl,
@@ -105,6 +110,13 @@ export default {
   },
   template: `
     <td class="column-chart d-none d-lg-table-cell" :id="'root-distance-' + idx ">
+      <div class="chart-top-container" v-if="max_value > 20">
+        <div class="chart-top-value"
+             :style="{ left: max_value_position }">
+          {{ max_value }}
+        </div>
+      </div>
+    
       <canvas :id=" 'spark_line_block_distance_' + validator['account'] " width="5%"></canvas>
     </td>
   `

--- a/app/javascript/packs/stake_accounts/charts/root_distance_chart.js
+++ b/app/javascript/packs/stake_accounts/charts/root_distance_chart.js
@@ -117,7 +117,7 @@ export default {
         </div>
       </div>
     
-      <canvas :id=" 'spark_line_block_distance_' + validator['account'] " width="5%"></canvas>
+      <canvas :id=" 'spark_line_block_distance_' + validator['account'] "></canvas>
     </td>
   `
 }

--- a/app/javascript/packs/stake_accounts/charts/skipped_slot_chart.js
+++ b/app/javascript/packs/stake_accounts/charts/skipped_slot_chart.js
@@ -123,7 +123,7 @@ export default {
   },
   template: `
     <td class="column-chart d-none d-lg-table-cell" :id="'skipped-slots-' + idx ">
-      <canvas :id=" 'spark_line_skipped_slots_' + validator['account'] " width="5%"></canvas>
+      <canvas :id=" 'spark_line_skipped_slots_' + validator['account'] "></canvas>
     </td>
   `
 }

--- a/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
+++ b/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
@@ -90,12 +90,12 @@ export default {
         <div class="d-none d-lg-block">
           <canvas :id="'spark_line_skipped_vote_' + validator['account'] " width="5%"></canvas>
           <div class="text-center text-muted small mt-2">
-            {{ skipped_vote_percent() }}
+            {{ skipped_vote_percent() ? skipped_vote_percent() + "%" : "N / A" }}
           </div>
         </div>
         <span class="d-inline-block d-lg-none">
           Skipped Vote&nbsp;%:
-          {{ skipped_vote_percent() || 'N/A' }}
+          {{ skipped_vote_percent() ? skipped_vote_percent() + "%" : "N / A" }}
         </span>
       </div>
     </td>

--- a/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
+++ b/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
@@ -88,11 +88,12 @@ export default {
     <td class="column-speedometer">
       <div v-if="skipped_vote_percent">
         <div class="d-none d-lg-block">
-          <canvas :id="'spark_line_skipped_vote_' + validator['account'] " width="5%" v-if="skipped_vote_percent()"></canvas>
+          <canvas :id="'spark_line_skipped_vote_' + validator['account'] " v-if="skipped_vote_percent()"></canvas>
           <div class="text-center text-muted small mt-2">
             {{ skipped_vote_percent() ? skipped_vote_percent() + "%" : "N / A" }}
           </div>
         </div>
+        
         <span class="d-inline-block d-lg-none">
           Skipped Vote&nbsp;%:
           {{ skipped_vote_percent() ? skipped_vote_percent() + "%" : "N / A" }}

--- a/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
+++ b/app/javascript/packs/stake_accounts/charts/skipped_vote_speedometer.js
@@ -88,7 +88,7 @@ export default {
     <td class="column-speedometer">
       <div v-if="skipped_vote_percent">
         <div class="d-none d-lg-block">
-          <canvas :id="'spark_line_skipped_vote_' + validator['account'] " width="5%"></canvas>
+          <canvas :id="'spark_line_skipped_vote_' + validator['account'] " width="5%" v-if="skipped_vote_percent()"></canvas>
           <div class="text-center text-muted small mt-2">
             {{ skipped_vote_percent() ? skipped_vote_percent() + "%" : "N / A" }}
           </div>

--- a/app/javascript/packs/stake_accounts/charts/vote_distance_chart.js
+++ b/app/javascript/packs/stake_accounts/charts/vote_distance_chart.js
@@ -116,7 +116,7 @@ export default {
         </div>
       </div>
       
-      <canvas :id=" 'spark_line_vote_distance_' + validator['account'] " width="5%"></canvas>
+      <canvas :id=" 'spark_line_vote_distance_' + validator['account'] "></canvas>
     </td>
   `
 }

--- a/app/javascript/packs/stake_accounts/charts/vote_distance_chart.js
+++ b/app/javascript/packs/stake_accounts/charts/vote_distance_chart.js
@@ -16,9 +16,13 @@ export default {
     }
   },
   data() {
-    var vote_distance_vl = Math.min.apply(Math, [60, this.validator['vote_distance_history'].length])
-    var vote_distance_vector = this.validator['vote_distance_history'].slice(Math.max(this.validator['vote_distance_history'].length - vote_distance_vl, 0))
+    var vote_distance_vl = Math.min.apply(Math, [60, this.validator['vote_distance_history'].length]);
+    var vote_distance_vector = this.validator['vote_distance_history'].slice(Math.max(this.validator['vote_distance_history'].length - vote_distance_vl, 0));
+    var max_value = Math.max.apply(Math, vote_distance_vector);
+    var max_value_position = this.$parent.max_value_position(vote_distance_vector);
     return {
+      max_value: max_value,
+      max_value_position: max_value_position,
       y_root_distance_max: 20,
       vote_distance_chart: {
         vl: vote_distance_vl,
@@ -105,6 +109,13 @@ export default {
   },
   template: `
     <td class="column-chart d-none d-lg-table-cell" :id="'vote-distance-' + idx ">
+      <div class="chart-top-container" v-if="max_value > 20">
+        <div class="chart-top-value"
+             :style="{ left: max_value_position }">
+          {{ max_value }}
+        </div>
+      </div>
+      
       <canvas :id=" 'spark_line_vote_distance_' + validator['account'] " width="5%"></canvas>
     </td>
   `

--- a/app/javascript/packs/stake_accounts/stake_account_row.js
+++ b/app/javascript/packs/stake_accounts/stake_account_row.js
@@ -65,13 +65,14 @@ var StakeAccountRow = Vue.component('StakeAccountRow', {
             <tr v-for="stake_account in stake_accounts_for_val" :key="stake_account.id">
               <td class="word-break">
                 <strong class="d-inline-block d-lg-none">Stake Account:&nbsp;&nbsp;</strong>{{ stake_account.stake_pubkey }}
-                <br />
-                <strong class="d-inline-block d-lg-none">Staker:&nbsp;&nbsp;</strong>{{ stake_account.staker }}
+                <div class="text-muted">
+                  <strong class="d-inline-block d-lg-none">Staker:&nbsp;&nbsp;</strong>
+                  {{ stake_account.staker }}
+                </div>
               </td>
               <td class="word-break">
                 <strong class="d-inline-block d-lg-none">Withdrawer:&nbsp;&nbsp;</strong>{{ stake_account.pool_name }}
-                <br />
-                {{ stake_account.withdrawer }}
+                <div class="text-muted">{{ stake_account.withdrawer }}</div>
               </td>
               <td>
                 <strong class="d-inline-block d-lg-none">Stake:&nbsp;</strong>

--- a/app/javascript/packs/stake_accounts/validator_row.js
+++ b/app/javascript/packs/stake_accounts/validator_row.js
@@ -73,6 +73,7 @@ var ValidatorRow = Vue.component('validatorRow', {
       }
       return chart_lightgrey
     },
+
     chart_fill_color(val) {
       if (val == 2) {
         return chart_green_t
@@ -81,6 +82,7 @@ var ValidatorRow = Vue.component('validatorRow', {
       }
       return chart_lightgrey_t
     },
+
     display_chart(target, event){
       var i = this.idx;
       var target = target+'-'+i;
@@ -100,6 +102,23 @@ var ValidatorRow = Vue.component('validatorRow', {
       });
       event.target.classList.add('active');
     },
+
+    // Set max_value position for root & vote distance charts
+    max_value_position(vector) {
+      var max_value = Math.max.apply(Math, vector);
+      var max_value_index = vector.indexOf(max_value).toFixed(2);
+      var vector_length = vector.length.toFixed(2);
+      var position = (max_value_index / vector_length * 100).toFixed(0);
+      position = Math.max.apply(Math, [position, 2])
+      // set max position for large numbers
+      if (max_value > 100000) {
+        position = Math.min.apply(Math, [position, 70])
+      } else if(max_value > 10000) {
+        position = Math.min.apply(Math, [position, 80])
+      }
+      return position + "%";
+    },
+
     displayed_total_score() {
       if(this.validator["commission"] == 100 && this.validator["network"] == 'mainnet'){
         return 'N/A'

--- a/app/views/validators/_table.html.erb
+++ b/app/views/validators/_table.html.erb
@@ -232,8 +232,10 @@
         %>
         <% max_value = vector&.max %>
         <% if max_value && max_value > Y_ROOT_DISTANCE_MAX %>
-          <div class="chart-top-value">
-            <%= max_value %>
+          <div class="chart-top-container">
+            <div class="chart-top-value" style="left: <%= max_value_position(vector) %>">
+              <%= max_value %>
+            </div>
           </div>
         <% end %>
         <%= render 'validators/spark_line_block_distance',
@@ -254,8 +256,10 @@
         %>
         <% max_value = vote_vector&.max %>
         <% if max_value && max_value > Y_VOTE_DISTANCE_MAX %>
-          <div class="chart-top-value">
-            <%= max_value %>
+          <div class="chart-top-container">
+            <div class="chart-top-value" style="left: <%= max_value_position(vector) %>">
+              <%= max_value %>
+            </div>
           </div>
         <% end %>
         <%= render 'validators/spark_line_vote_distance',


### PR DESCRIPTION
#### What's this PR do?
- Moves max chart value to the right place above the charts

#### How should this be manually tested?
- Generate data for the charts (gather_rpc and validator_score daemons)
- Go to the main page, find a chart with max value larger than 20 and confirm that max value is displayed in the right place (see screenshot in PT story)
- Generate data for stake pools (see ## STAKE POOLS section in db instructions)
- Check the same on stake pools page (localhost:3000/stake-pools)

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/183370357)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
