### PR TITLE
183466933 add gossip node status

### DIFF
--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -43,15 +43,16 @@ module GossipNodeLogic
 
   def set_inactive_nodes_status
     lambda do |p|
-      active_nodes_identities = p.payload[:current_nodes].map { |cn| cn["identityPubkey"] }
+      active_nodes_identities = p.payload[:current_nodes]&.map { |cn| cn["identityPubkey"] }
       GossipNode.where(network: p.payload[:network]).each do |gn|
-        unless active_nodes_identities.include? gn.account
+        unless active_nodes_identities&.include? gn.account
           gn.is_active = false
-          gn.save if gn.changed?
+          gn.save if gn.will_save_change_to_attribute?(:is_active)
         end
       end
       Pipeline.new(200, p.payload)
     rescue StandardError => e
+      puts e
       Pipeline.new(500, p.payload, "Error from set_inactive_nodes_status", e)
     end
   end

--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -47,7 +47,7 @@ module GossipNodeLogic
       GossipNode.where(network: p.payload[:network]).each do |gn|
         unless active_nodes_identities.include? gn.account
           gn.is_active = false
-          gn.save if gn.will_save_change_to_attribute?(:is_active)
+          gn.save if gn.changed?
         end
       end
       Pipeline.new(200, p.payload)

--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -47,7 +47,7 @@ module GossipNodeLogic
       GossipNode.where(network: p.payload[:network]).each do |gn|
         unless active_nodes_identities.include? gn.account
           gn.is_active = false
-          gn.save if gn.changed?
+          gn.save if gn.will_save_change_to_attribute?(:is_active)
         end
       end
       Pipeline.new(200, p.payload)

--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -28,6 +28,7 @@ module GossipNodeLogic
         db_node.tpu_port = node["tpuPort"]
         db_node.gossip_port = node["gossipPort"]
         db_node.software_version = node["version"]
+        db_node.is_active = true
 
         db_node.save if db_node.changed?
 
@@ -40,8 +41,23 @@ module GossipNodeLogic
     end
   end
 
-  def set_staked_flag
+  def set_inactive_nodes_status
     lambda do |p|
+      active_nodes_identities = p.payload[:current_nodes].map { |cn| cn["identityPubkey"] }
+      GossipNode.where(network: p.payload[:network]).each do |gn|
+        unless active_nodes_identities.include? gn.account
+          gn.is_active = false
+          gn.save if gn.changed?
+        end
+      end
+      Pipeline.new(200, p.payload)
+    rescue StandardError => e
+      Pipeline.new(500, p.payload, "Error from set_inactive_nodes_status", e)
+    end
+  end
+
+  def set_staked_flag
+    lambgda do |p|
       staked_validators = Validator.joins(:validator_score_v1)
                                    .includes(:validator_ip_active)
                                    .where("validator_score_v1s.active_stake > 0")

--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -57,7 +57,7 @@ module GossipNodeLogic
   end
 
   def set_staked_flag
-    lambgda do |p|
+    lambda do |p|
       staked_validators = Validator.joins(:validator_score_v1)
                                    .includes(:validator_ip_active)
                                    .where("validator_score_v1s.active_stake > 0")

--- a/app/logic/gossip_node_logic.rb
+++ b/app/logic/gossip_node_logic.rb
@@ -52,7 +52,6 @@ module GossipNodeLogic
       end
       Pipeline.new(200, p.payload)
     rescue StandardError => e
-      puts e
       Pipeline.new(500, p.payload, "Error from set_inactive_nodes_status", e)
     end
   end

--- a/app/models/gossip_node.rb
+++ b/app/models/gossip_node.rb
@@ -39,6 +39,8 @@ class GossipNode < ApplicationRecord
   has_one :data_center, -> { for_api }, through: :validator_ip_active
   has_one :validator, -> { for_api }, primary_key: :account, foreign_key: :account
 
+  scope :active, ->() { where(is_active: true) }
+
   def add_validator_ip
     ValidatorIp.find_or_create_by(address: self.ip, is_active: true)
   end

--- a/app/models/gossip_node.rb
+++ b/app/models/gossip_node.rb
@@ -18,8 +18,9 @@
 #
 # Indexes
 #
-#  index_gossip_nodes_on_network_and_account  (network,account)
-#  index_gossip_nodes_on_network_and_staked   (network,staked)
+#  index_gossip_nodes_on_network_and_account    (network,account)
+#  index_gossip_nodes_on_network_and_is_active  (network,is_active)
+#  index_gossip_nodes_on_network_and_staked     (network,staked)
 #
 
 class GossipNode < ApplicationRecord

--- a/app/models/gossip_node.rb
+++ b/app/models/gossip_node.rb
@@ -8,6 +8,7 @@
 #  account          :string(191)
 #  gossip_port      :integer
 #  ip               :string(191)
+#  is_active        :boolean          default(TRUE)
 #  network          :string(191)
 #  software_version :string(191)
 #  staked           :boolean          default(FALSE)

--- a/app/queries/gossip_node_query.rb
+++ b/app/queries/gossip_node_query.rb
@@ -8,18 +8,19 @@ class GossipNodeQuery
     @query_fields = query_fields
     @query = GossipNode.select(query_fields)
                        .joins(
-                         "LEFT OUTER JOIN validators 
-                          ON validators.account = gossip_nodes.account 
+                         "LEFT OUTER JOIN validators
+                          ON validators.account = gossip_nodes.account
                           AND validators.network = gossip_nodes.network"
                        ).left_outer_joins(:data_center)
                        .where(network: @network)
+                       .active
   end
 
   def call(staked: nil, per: 100, page: 1)
     unless staked.nil?
       @query = @query.where(staked: staked)
     end
-    
+
     @query.page(page).per(per)
   end
 

--- a/db/migrate/20221005162534_add_is_active_to_gossip_node.rb
+++ b/db/migrate/20221005162534_add_is_active_to_gossip_node.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToGossipNode < ActiveRecord::Migration[6.1]
+  def change
+    add_column :gossip_nodes, :is_active, :boolean, default: true
+  end
+end

--- a/db/migrate/20221005162534_add_is_active_to_gossip_node.rb
+++ b/db/migrate/20221005162534_add_is_active_to_gossip_node.rb
@@ -1,5 +1,6 @@
 class AddIsActiveToGossipNode < ActiveRecord::Migration[6.1]
   def change
     add_column :gossip_nodes, :is_active, :boolean, default: true
+    add_index :gossip_nodes, %i[network is_active]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_22_145718) do
+ActiveRecord::Schema.define(version: 2022_10_05_162534) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(version: 2022_09_22_145718) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "staked", default: false
+    t.boolean "is_active", default: true
     t.index ["network", "account"], name: "index_gossip_nodes_on_network_and_account"
     t.index ["network", "staked"], name: "index_gossip_nodes_on_network_and_staked"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2022_10_05_162534) do
     t.boolean "staked", default: false
     t.boolean "is_active", default: true
     t.index ["network", "account"], name: "index_gossip_nodes_on_network_and_account"
+    t.index ["network", "is_active"], name: "index_gossip_nodes_on_network_and_is_active"
     t.index ["network", "staked"], name: "index_gossip_nodes_on_network_and_staked"
   end
 

--- a/script/update_gossip_nodes.rb
+++ b/script/update_gossip_nodes.rb
@@ -15,6 +15,7 @@ include GossipNodeLogic
   p = Pipeline.new(200, payload)
               .then(&get_nodes)
               .then(&update_nodes)
+              .then(&set_inactive_nodes_status)
               .then(&set_staked_flag)
 
   logger.info "Finished at #{DateTime.now} with status #{p.code}"

--- a/test/controllers/api/v1/gossip_nodes_controller_test.rb
+++ b/test/controllers/api/v1/gossip_nodes_controller_test.rb
@@ -34,6 +34,6 @@ class GossipNodesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response 200
     api_nodes = response_to_json(@response.body)
-    assert_equal false, api_nodes.include?(inactive_node)
+    refute api_nodes.include?(inactive_node)
   end
 end

--- a/test/controllers/api/v1/gossip_nodes_controller_test.rb
+++ b/test/controllers/api/v1/gossip_nodes_controller_test.rb
@@ -10,7 +10,7 @@ class GossipNodesControllerTest < ActionDispatch::IntegrationTest
 
     @user = create(:user)
     @headers = { "Token" => @user.api_token }
-    @gossip_nodes = create_list(:gossip_node, 60) 
+    @gossip_nodes = create_list(:gossip_node, 60)
   end
 
   test "GET api_v1_gossip_nodes without token returns error" do
@@ -26,5 +26,14 @@ class GossipNodesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response 200
     assert_equal 60, response_to_json(@response.body).size
+  end
+
+  test "GET api_v1_gossip_nodes returns only active nodes" do
+    inactive_node = create(:gossip_node, :inactive)
+    get api_v1_gossip_nodes_path(network: @network), headers: @headers
+
+    assert_response 200
+    api_nodes = response_to_json(@response.body)
+    assert_equal false, api_nodes.include?(inactive_node)
   end
 end

--- a/test/factories/gossip_nodes.rb
+++ b/test/factories/gossip_nodes.rb
@@ -7,5 +7,10 @@ FactoryBot.define do
     gossip_port { 8001 }
     software_version { Faker::App.semantic_version }
     network { "testnet" }
+    is_active { true }
+  end
+
+  trait :inactive do
+    is_active { false }
   end
 end

--- a/test/logic/gossip_node_logic_test.rb
+++ b/test/logic/gossip_node_logic_test.rb
@@ -50,6 +50,7 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
       refute p.payload[:current_nodes].blank?
       assert GossipNode.exists?
       assert_equal @network, GossipNode.last.network
+      assert GossipNode.last.is_active
       refute GossipNode.where(account: nil).exists?
       refute GossipNode.where(ip: nil).exists?
     end

--- a/test/logic/gossip_node_logic_test.rb
+++ b/test/logic/gossip_node_logic_test.rb
@@ -63,7 +63,8 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
                 .then(&get_nodes)
                 .then(&update_nodes)
                 .then(&set_inactive_nodes_status)
-    
+
+    assert_equal 200, p.code
     assert_equal false, not_existing_node.reload.is_active
   end
 

--- a/test/logic/gossip_node_logic_test.rb
+++ b/test/logic/gossip_node_logic_test.rb
@@ -63,8 +63,7 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
                 .then(&get_nodes)
                 .then(&update_nodes)
                 .then(&set_inactive_nodes_status)
-
-    assert_equal 200, p.code
+    
     assert_equal false, not_existing_node.reload.is_active
   end
 

--- a/test/logic/gossip_node_logic_test.rb
+++ b/test/logic/gossip_node_logic_test.rb
@@ -55,12 +55,25 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
     end
   end
 
+  test "set_inactive_nodes_status correctly updates status for inactive nodes" do
+    not_existing_node = create(:gossip_node, account: "AAAAAAAAAA", network: @network)
+    assert_equal true, not_existing_node.is_active
+
+    p = Pipeline.new(200, @payload)
+                .then(&get_nodes)
+                .then(&update_nodes)
+                .then(&set_inactive_nodes_status)
+
+    assert_equal 200, p.code
+    assert_equal false, not_existing_node.reload.is_active
+  end
+
   test "set_staked_flag correctly updates staked" do
     ip = "204.16.244.218"
     account = "HZF34Kzkn8fh88TJV6KfgZGmBRBiFX9bXdmsnoQBVTMk"
-    
+
     val = create(:validator, network: @network, account: account)
-    
+
     create(
       :validator_score_v1,
       validator: val,
@@ -74,6 +87,7 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
       p = Pipeline.new(200, @payload)
                   .then(&get_nodes)
                   .then(&update_nodes)
+                  .then(&set_inactive_nodes_status)
                   .then(&set_staked_flag)
 
       staked_nodes = GossipNode.where(staked: true)

--- a/test/logic/gossip_node_logic_test.rb
+++ b/test/logic/gossip_node_logic_test.rb
@@ -58,7 +58,7 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
 
   test "set_inactive_nodes_status correctly updates status for inactive nodes" do
     not_existing_node = create(:gossip_node, account: "AAAAAAAAAA", network: @network)
-    assert_equal true, not_existing_node.is_active
+    assert not_existing_node.is_active
 
     p = Pipeline.new(200, @payload)
                 .then(&get_nodes)
@@ -66,7 +66,7 @@ class GossipNodeLogicTest < ActiveSupport::TestCase
                 .then(&set_inactive_nodes_status)
 
     assert_equal 200, p.code
-    assert_equal false, not_existing_node.reload.is_active
+    refute not_existing_node.reload.is_active
   end
 
   test "set_staked_flag correctly updates staked" do

--- a/test/models/gossip_node_test.rb
+++ b/test/models/gossip_node_test.rb
@@ -48,7 +48,14 @@ class GossipNodeTest < ActiveSupport::TestCase
   test "relationship has_one validator_ip_active returns correct validator_ip" do
     validator_ip = create(:validator_ip, validator: @validator, address: @ip)
     validator_ip2 = create(:validator_ip, :active, validator: @validator, address: @ip)
-    
+
     assert_equal validator_ip2, @node.validator_ip_active
+  end
+
+  test "active scope returns only active nodes" do
+    inactive_node = create(:gossip_node, :inactive)
+
+    assert_equal 1, GossipNode.active.count
+    refute GossipNode.active.include? inactive_node
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Adds is_active attribute to gossip nodes

#### How should this be manually tested?
- Run migration
- Confirm the script runs without any errors: `rails r script/update_gossip_nodes.rb`
- If you had some gossip nodes already in your db, then those which don't exist anymore should become inactive (check the number in console `GossipNode.where(is_active: false).count`)
- If you didn't have any gossip nodes in your local db, then all new nodes should be active (confirm in console `GossipNode.where(is_active: false).count` - should be 0)
- Use API to get gossip nodes: https://stage.validators.app/api-documentation?locale=en&network=mainnet#gossip-nodes. Confirm that the output no longer includes inactive gossip nodes.

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/183466933)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
