### PR TITLE
183466948 update data center stats

### DIFF
--- a/app/controllers/api/v1/data_centers_controller.rb
+++ b/app/controllers/api/v1/data_centers_controller.rb
@@ -26,13 +26,8 @@ module Api
                                    dc_params[:network]
                                  ).order(:validators_count)
 
-        total_active_validators_count = data_centers.sum{ |dc| dc[:active_validators_count] }
-        total_active_nodes_count = data_centers.sum{ |dc| dc[:active_gossip_nodes_count] }
-
         render json: {
-          data_centers: data_centers,
-          total_active_validators_count: total_active_validators_count,
-          total_active_nodes_count: total_active_nodes_count
+          data_centers: data_centers
         }, status: :ok
       end
 

--- a/app/controllers/api/v1/data_centers_controller.rb
+++ b/app/controllers/api/v1/data_centers_controller.rb
@@ -20,19 +20,19 @@ module Api
                                  .where(
                                    "data_center_stats.network = ?
                                    AND (
-                                     data_center_stats.gossip_nodes_count > 0
-                                     OR data_center_stats.validators_count > 0
+                                     data_center_stats.active_gossip_nodes_count > 0
+                                     OR data_center_stats.active_validators_count > 0
                                    )",
                                    dc_params[:network]
                                  ).order(:validators_count)
 
-        total_validators_count = data_centers.sum{ |dc| dc[:validators_count] }
-        total_nodes_count = data_centers.sum{ |dc| dc[:gossip_nodes_count] }
+        total_active_validators_count = data_centers.sum{ |dc| dc[:active_validators_count] }
+        total_active_nodes_count = data_centers.sum{ |dc| dc[:active_gossip_nodes_count] }
 
         render json: {
           data_centers: data_centers,
-          total_validators_count: total_validators_count,
-          total_nodes_count: total_nodes_count
+          total_active_validators_count: total_active_validators_count,
+          total_active_nodes_count: total_active_nodes_count
         }, status: :ok
       end
 

--- a/app/javascript/packs/validators/validators_map.vue
+++ b/app/javascript/packs/validators/validators_map.vue
@@ -29,13 +29,8 @@
 
     <section class="map-legend">
       <div class="map-legend-col">
-        <small class="text-muted">Total in {{ network }}</small>
-        <div class="small">
-          <strong class="text-success">{{ total_active_validators_count }}</strong> Validators
-        </div>
-        <div class="small">
-          <strong class="text-success">{{ total_active_nodes_count }}</strong> Nodes
-        </div>
+        <div class="small text-muted">Current Leader placeholder</div>
+        <small class="text-muted">{{ network }}</small>
       </div>
 
       <div class="map-legend-col" v-if="selected_data_center">
@@ -61,8 +56,6 @@
       return {
         api_url: api_url,
         data_centers: [],
-        total_active_validators_count: 0,
-        total_active_nodes_count: 0,
         selected_data_center: null,
       }
     },
@@ -72,8 +65,6 @@
 
       axios.get(url).then(function (response) {
         ctx.data_centers = response.data.data_centers;
-        ctx.total_active_validators_count = response.data.total_active_validators_count;
-        ctx.total_active_nodes_count = response.data.total_active_nodes_count;
       })
     },
     watch: {

--- a/app/javascript/packs/validators/validators_map.vue
+++ b/app/javascript/packs/validators/validators_map.vue
@@ -22,7 +22,7 @@
                        bottom: position_vertical(data_center.latitude) }"
              :title="data_center.data_center_key"
              v-on:click="select_data_center(data_center)">
-          {{ data_center.validators_count }}
+          {{ data_center.active_validators_count + data_center.active_gossip_nodes_count }}
         </div>
       </div>
     </section>
@@ -31,10 +31,10 @@
       <div class="map-legend-col">
         <small class="text-muted">Total in {{ network }}</small>
         <div class="small">
-          <strong class="text-success">{{ total_validators_count }}</strong> Validators
+          <strong class="text-success">{{ total_active_validators_count }}</strong> Validators
         </div>
         <div class="small">
-          <strong class="text-success">{{ total_nodes_count }}</strong> Nodes
+          <strong class="text-success">{{ total_active_nodes_count }}</strong> Nodes
         </div>
       </div>
 
@@ -61,8 +61,8 @@
       return {
         api_url: api_url,
         data_centers: [],
-        total_validators_count: 0,
-        total_nodes_count: 0,
+        total_active_validators_count: 0,
+        total_active_nodes_count: 0,
         selected_data_center: null,
       }
     },
@@ -72,8 +72,8 @@
 
       axios.get(url).then(function (response) {
         ctx.data_centers = response.data.data_centers;
-        ctx.total_validators_count = response.data.total_validators_count;
-        ctx.total_nodes_count = response.data.total_nodes_count;
+        ctx.total_active_validators_count = response.data.total_active_validators_count;
+        ctx.total_active_nodes_count = response.data.total_active_nodes_count;
       })
     },
     watch: {

--- a/app/javascript/packs/validators/validators_map_data_center_details.js
+++ b/app/javascript/packs/validators/validators_map_data_center_details.js
@@ -14,10 +14,10 @@ var ValidatorsMapDataCenterDetails = Vue.component('ValidatorsMapDataCenterDetai
     <div>
       <strong class="text-purple">{{ data_center.data_center_key }}</strong>
       <div class="small text-muted">
-        {{ data_center.validators_count }} validator(s)
+        {{ data_center.active_validators_count }} validator(s)
       </div>
       <div class="small text-muted">
-        {{ data_center.gossip_nodes_count }} node(s)
+        {{ data_center.active_gossip_nodes_count }} node(s)
       </div>
     </div>
   `

--- a/app/models/data_center_stat.rb
+++ b/app/models/data_center_stat.rb
@@ -24,7 +24,7 @@
 #  fk_rails_...  (data_center_id => data_centers.id)
 #
 class DataCenterStat < ApplicationRecord
-  FIELDS_FOR_API = %w[gossip_nodes_count validators_count].freeze
+  FIELDS_FOR_API = %w[active_gossip_nodes_count active_validators_count].freeze
 
   belongs_to :data_center
 

--- a/app/models/data_center_stat.rb
+++ b/app/models/data_center_stat.rb
@@ -4,13 +4,15 @@
 #
 # Table name: data_center_stats
 #
-#  id                 :bigint           not null, primary key
-#  gossip_nodes_count :integer
-#  network            :string(191)
-#  validators_count   :integer
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  data_center_id     :bigint           not null
+#  id                        :bigint           not null, primary key
+#  active_gossip_nodes_count :integer
+#  active_validators_count   :integer
+#  gossip_nodes_count        :integer
+#  network                   :string(191)
+#  validators_count          :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  data_center_id            :bigint           not null
 #
 # Indexes
 #

--- a/app/services/data_centers/fill_data_center_stats.rb
+++ b/app/services/data_centers/fill_data_center_stats.rb
@@ -9,8 +9,8 @@ class DataCenters::FillDataCenterStats
     DataCenter.includes(:validators, :gossip_nodes).all.each do |dc|
       validators_count = dc.validators.where(network: @network).size
       active_validators_count = dc.validators.where(network: @network).active.size
-      nodes_count = dc.gossip_nodes.where(network: @network).size
-      active_nodes_count = dc.gossip_nodes.where(network: @network).active.size
+      nodes_count = dc.gossip_nodes.where(network: @network, staked: false).size
+      active_nodes_count = dc.gossip_nodes.where(network: @network, staked: false).active.size
 
       stats = dc.data_center_stats.find_or_create_by(network: @network)
       stats.validators_count = validators_count

--- a/app/services/data_centers/fill_data_center_stats.rb
+++ b/app/services/data_centers/fill_data_center_stats.rb
@@ -8,11 +8,15 @@ class DataCenters::FillDataCenterStats
   def call
     DataCenter.includes(:validators, :gossip_nodes).all.each do |dc|
       validators_count = dc.validators.where(network: @network).size
+      active_validators_count = dc.validators.where(network: @network).active.size
       nodes_count = dc.gossip_nodes.where(network: @network).size
+      active_nodes_count = dc.gossip_nodes.where(network: @network).active.size
 
       stats = dc.data_center_stats.find_or_create_by(network: @network)
       stats.validators_count = validators_count
+      stats.active_validators_count = active_validators_count
       stats.gossip_nodes_count = nodes_count
+      stats.active_gossip_nodes_count = active_nodes_count
 
       stats.save if stats.changed?
     end

--- a/db/migrate/20221011131406_add_active_validators_count_to_data_center_stats.rb
+++ b/db/migrate/20221011131406_add_active_validators_count_to_data_center_stats.rb
@@ -1,0 +1,6 @@
+class AddActiveValidatorsCountToDataCenterStats < ActiveRecord::Migration[6.1]
+  def change
+    add_column :data_center_stats, :active_validators_count, :integer
+    add_column :data_center_stats, :active_gossip_nodes_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_05_162534) do
+ActiveRecord::Schema.define(version: 2022_10_11_131406) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -128,6 +128,8 @@ ActiveRecord::Schema.define(version: 2022_10_05_162534) do
     t.string "network"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "active_validators_count"
+    t.integer "active_gossip_nodes_count"
     t.index ["data_center_id"], name: "index_data_center_stats_on_data_center_id"
     t.index ["network", "data_center_id"], name: "index_data_center_stats_on_network_and_data_center_id", unique: true
   end

--- a/test/controllers/api/v1/data_centers_controller_test.rb
+++ b/test/controllers/api/v1/data_centers_controller_test.rb
@@ -13,8 +13,8 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
       :data_center_stat,
       data_center: @data_center,
       network: @network,
-      gossip_nodes_count: 1,
-      validators_count: 1
+      active_gossip_nodes_count: 1,
+      active_validators_count: 1
     )
 
     @user = create(:user)
@@ -49,8 +49,8 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
       :data_center_stat,
       data_center: empty_dc,
       network: @network,
-      gossip_nodes_count: 0,
-      validators_count: 0
+      active_gossip_nodes_count: 0,
+      active_validators_count: 0
     )
 
     get api_v1_data_centers_with_nodes_url(network: @network), headers: @headers
@@ -58,8 +58,8 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response 200
     assert_equal 3, resp.keys.count
-    assert_equal 1, resp["data_centers"].first["gossip_nodes_count"]
-    assert_equal 1, resp["data_centers"].first["validators_count"]
+    assert_equal 1, resp["data_centers"].first["active_gossip_nodes_count"]
+    assert_equal 1, resp["data_centers"].first["active_validators_count"]
   end
 
   test "#data_centers_with_nodes response does not include unknown data center" do
@@ -87,8 +87,8 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
       :data_center_stat,
       data_center: data_center_frankfurt,
       network: @network,
-      gossip_nodes_count: 6,
-      validators_count: 4
+      active_gossip_nodes_count: 6,
+      active_validators_count: 4
     )
 
     get api_v1_data_centers_with_nodes_url(network: @network), headers: @headers
@@ -96,7 +96,7 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response 200
     assert_equal 3, resp.keys.count
-    assert_equal 5, resp["total_validators_count"]
-    assert_equal 7, resp["total_nodes_count"]
+    assert_equal 5, resp["total_active_validators_count"]
+    assert_equal 7, resp["total_active_nodes_count"]
   end
 end

--- a/test/controllers/api/v1/data_centers_controller_test.rb
+++ b/test/controllers/api/v1/data_centers_controller_test.rb
@@ -39,7 +39,7 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
     resp = response_to_json(@response.body)
 
     assert_response 200
-    assert_equal 3, resp.keys.count
+    assert_equal 1, resp.keys.count
     assert_equal 7, resp["data_centers"].first.keys.count
   end
 
@@ -57,7 +57,7 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
     resp = JSON.parse(@response.body)
 
     assert_response 200
-    assert_equal 3, resp.keys.count
+    assert_equal 1, resp.keys.count
     assert_equal 1, resp["data_centers"].first["active_gossip_nodes_count"]
     assert_equal 1, resp["data_centers"].first["active_validators_count"]
   end
@@ -68,35 +68,14 @@ class DataCentersControllerTest < ActionDispatch::IntegrationTest
     create(
       :data_center_stat,
       data_center: unknown_dc,
-      network: @network,
-      gossip_nodes_count: 0,
-      validators_count: 1
+      network: @network
     )
 
     get api_v1_data_centers_with_nodes_url(network: @network), headers: @headers
     resp = JSON.parse(@response.body)
 
     assert_response 200
-    assert_equal 3, resp.keys.count
+    assert_equal 1, resp.keys.count
     refute resp["data_centers"].map{|dc| dc["data_center_key"]}.include? "0--Unknown"
-  end
-
-  test "#data_centers_with_nodes response returns correct validators and nodes sums" do
-    data_center_frankfurt = create(:data_center, :frankfurt)
-    create(
-      :data_center_stat,
-      data_center: data_center_frankfurt,
-      network: @network,
-      active_gossip_nodes_count: 6,
-      active_validators_count: 4
-    )
-
-    get api_v1_data_centers_with_nodes_url(network: @network), headers: @headers
-    resp = JSON.parse(@response.body)
-
-    assert_response 200
-    assert_equal 3, resp.keys.count
-    assert_equal 5, resp["total_active_validators_count"]
-    assert_equal 7, resp["total_active_nodes_count"]
   end
 end

--- a/test/factories/data_center_stats.rb
+++ b/test/factories/data_center_stats.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :data_center_stat do
     gossip_nodes_count { 1 }
+    active_gossip_nodes_count { 1 }
     validators_count { 1 }
+    active_validators_count { 1 }
     network { "testnet" }
     data_center
   end

--- a/test/services/data_centers/fill_data_center_stats_test.rb
+++ b/test/services/data_centers/fill_data_center_stats_test.rb
@@ -42,7 +42,7 @@ module DataCenters
       assert_equal 2, @data_center.data_center_stats.by_network(@network).gossip_nodes_count
     end
 
-    test "#call sets up active_validator_count and active_gossip_node_count correctly" do
+    test "#call sets up active_validators_count and active_gossip_nodes_count correctly" do
       DataCenters::FillDataCenterStats.new(network: @network).call
 
       assert_equal 0, @data_center.data_center_stats.by_network(@network).active_validators_count

--- a/test/services/data_centers/fill_data_center_stats_test.rb
+++ b/test/services/data_centers/fill_data_center_stats_test.rb
@@ -3,15 +3,15 @@
 require "test_helper"
 module DataCenters
   class FillDataCenterStatsTest < ActiveSupport::TestCase
-    setup do 
+    setup do
       @network = "mainnet"
       @data_center = create(:data_center, :berlin)
       host = create(:data_center_host, data_center: @data_center)
-      validator = create(:validator, network: @network)
-      node1 = create(:gossip_node, network: @network)
-      node2 = create(:gossip_node, network: @network)
-      create(:validator_ip, :active, data_center_host: host, address: node1.ip)
-      create(:validator_ip, :active, data_center_host: host, address: node2.ip, validator: validator)
+      @validator = create(:validator, network: @network, is_active: false)
+      @node1 = create(:gossip_node, :inactive, network: @network)
+      @node2 = create(:gossip_node, :inactive, network: @network)
+      create(:validator_ip, :active, data_center_host: host, address: @node1.ip)
+      create(:validator_ip, :active, data_center_host: host, address: @node2.ip, validator: @validator)
     end
 
     test "#call creates new data_center_stats if required" do
@@ -39,6 +39,22 @@ module DataCenters
       DataCenters::FillDataCenterStats.new(network: @network).call
 
       assert_equal 1, @data_center.data_center_stats.by_network(@network).validators_count
+      assert_equal 2, @data_center.data_center_stats.by_network(@network).gossip_nodes_count
+    end
+
+    test "#call sets up active_validator_count and active_gossip_node_count correctly" do
+      DataCenters::FillDataCenterStats.new(network: @network).call
+
+      assert_equal 0, @data_center.data_center_stats.by_network(@network).active_validators_count
+      assert_equal 0, @data_center.data_center_stats.by_network(@network).active_gossip_nodes_count
+
+      @validator.update(is_active: true)
+      @node1.update(is_active: true)
+      DataCenters::FillDataCenterStats.new(network: @network).call
+
+      assert_equal 1, @data_center.data_center_stats.by_network(@network).active_validators_count
+      assert_equal 1, @data_center.data_center_stats.by_network(@network).validators_count
+      assert_equal 1, @data_center.data_center_stats.by_network(@network).active_gossip_nodes_count
       assert_equal 2, @data_center.data_center_stats.by_network(@network).gossip_nodes_count
     end
   end


### PR DESCRIPTION
#### What's this PR do?
- Updates data center stats

#### How should this be manually tested?
- Run migrations, run sidekiq
- Generate some validators and nodes if you don't have any (gather daemon + update gossip nodes script)
- Generate some IPs and data centers if you don't fave any (`rails r script/data_centers_scripts/append_data_centers_geo_data.rb`)
- Update data center stats: `rails runner "DataCenterStatsWorker.perform_async('mainnet')"` and `rails runner "DataCenterStatsWorker.perform_async('testnet')"`
- Check your DataCenterStat through console, you should see 2 fields populated with some values: validators_count and active_validators_count; same for nodes: gossip_nodes_count and active_gossip_nodes_count
- You can try to manually deactivate one of validators or nodes assigned to your data centers (update is_active: false), and then run DataCenterStatsWorker again and if active_validators_count or active_gossip_nodes_count changed.

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/n/projects/2177859/stories/183466948)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
