### PR TITLE
183532155 - add front_stats_update to capistrano deploy config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -119,6 +119,7 @@ namespace :deamons do
           execute :systemctl, '--user', :start, :gather_rpc_testnet
           execute :systemctl, '--user', :start, :gather_vote_account_details
           execute :systemctl, '--user', :start, :process_ping_thing
+          execute :systemctl, '--user', :start, :front_stats_update
         end
       end
     end
@@ -135,6 +136,7 @@ namespace :deamons do
           execute :systemctl, '--user', :stop, :gather_rpc_testnet
           execute :systemctl, '--user', :stop, :gather_vote_account_details
           execute :systemctl, '--user', :stop, :process_ping_thing
+          execute :systemctl, '--user', :stop, :front_stats_update
         end
       end
     end
@@ -151,6 +153,7 @@ namespace :deamons do
           execute :systemctl, '--user', :restart, :gather_rpc_testnet
           execute :systemctl, '--user', :restart, :gather_vote_account_details
           execute :systemctl, '--user', :restart, :process_ping_thing
+          execute :systemctl, '--user', :restart, :front_stats_update
         end
       end
     end


### PR DESCRIPTION
#### What's this PR do?
Add front daemon to capistrano deploy config.

#### How should this be manually tested?
Should be tested on stage. The front daemon is utilized for gathering the SOL price at homepage.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183532155)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
