### PR TITLE
183590725 - add stake worker to testnet

### DIFF
--- a/app/javascript/packs/validators/circulating_supply.vue
+++ b/app/javascript/packs/validators/circulating_supply.vue
@@ -51,14 +51,15 @@
         });
     },
     computed: mapGetters([
-      'web3_url'
+      'web3_url',
+      'network'
     ]),
     channels: {
       FrontStatsChannel: {
         connected() {},
         rejected() {},
         received(data) {
-          var stake = data.cluster_stats["mainnet"]["total_active_stake"] // TODO alternate mainnet/testnet
+          const stake = data.cluster_stats[this.network].total_active_stake;
           this.total_active_stake = this.lamports_to_sol(stake).toLocaleString('en-US', { maximumFractionDigits: 0 });
         },
         disconnected() {},

--- a/daemons/validator_score_testnet_v1_daemon.rb
+++ b/daemons/validator_score_testnet_v1_daemon.rb
@@ -50,6 +50,11 @@ begin
       network: _p.payload[:network]
     )
 
+    ActiveStakeWorker.set(queue: :high_priority).perform_async(
+      batch_uuid: batch.uuid,
+      network: _p.payload[:network]
+    )
+
     break if interrupted
   rescue SkipAndSleep
     break if interrupted


### PR DESCRIPTION
#### What's this PR do?
PR adds the activeStakeWorker to daemon for testnet. Also it fixes the update on the homepage.

#### How should this be manually tested?
Make sure to have daemons running: 
daemons/validator_score_testnet_v1_daemon.rb
daemons/front_stats_update_daemon.rb

Verify the active stake values for testnet. You can manually change the last of ClusterStat in db (its total_active_stake attribute).

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183590725)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
