### PR TITLE
183637326 - remove cluster stats model attrs from the report

### DIFF
--- a/app/logic/report_logic.rb
+++ b/app/logic/report_logic.rb
@@ -156,11 +156,7 @@ module ReportLogic
       top_root_distance_validators: vs_stats.top_root_distance_averages_validators || [],
       top_vote_distance_validators: vs_stats.top_vote_distance_averages_validators || [],
       top_skipped_slot_validators: vbh_stats.top_skipped_slot_percent || [],
-      skipped_votes_percent: vah_stats.skipped_votes_stats,
       skipped_votes_percent_moving_average: vah_stats.skipped_vote_moving_average_stats,
-      root_distance: vs_stats.root_distance_stats,
-      vote_distance: vs_stats.vote_distance_stats,
-      skipped_slots: vbh_stats.skipped_slot_stats,
       software_version: software_report,
       batch_uuid: batch.uuid
     }

--- a/app/services/create_cluster_stats_service.rb
+++ b/app/services/create_cluster_stats_service.rb
@@ -18,10 +18,10 @@ class CreateClusterStatsService
       software_version: dominant_software_version,
       validator_count: validators_total,
       nodes_count: nodes_total,
-      root_distance: validator_score.root_distance_stats,
-      vote_distance: validator_score.vote_distance_stats,
-      skipped_slots: validator_block_history.skipped_slot_stats,
-      skipped_votes: vote_account_history.skipped_votes_stats
+      root_distance: validator_score_stats.root_distance_stats,
+      vote_distance: validator_score_stats.vote_distance_stats,
+      skipped_slots: validator_block_history_stats.skipped_slot_stats,
+      skipped_votes: vote_account_history_stats.skipped_votes_stats
     )
   end
 
@@ -31,15 +31,15 @@ class CreateClusterStatsService
     Stats::ValidatorHistory.new(@network, @batch_uuid)
   end
 
-  def vote_account_history
+  def vote_account_history_stats
     Stats::VoteAccountHistory.new(@network, @batch_uuid)
   end
 
-  def validator_block_history
+  def validator_block_history_stats
     Stats::ValidatorBlockHistory.new(@network, @batch_uuid)
   end
 
-  def validator_score
-    @validator_score ||= Stats::ValidatorScore.new(@network, @batch_uuid)
+  def validator_score_stats
+    @validator_score_stats ||= Stats::ValidatorScore.new(@network, @batch_uuid)
   end
 end

--- a/app/services/create_cluster_stats_service.rb
+++ b/app/services/create_cluster_stats_service.rb
@@ -8,29 +8,38 @@ class CreateClusterStatsService
   end
 
   def call
-    validator_history_stats = Stats::ValidatorHistory.new(@network, @batch_uuid)
-    total_active_stake = validator_history_stats.total_active_stake
-
     validators_total = Validator.where(network: @network).active.count
     nodes_total = GossipNode.where(network: @network).active.not_staked.count
     dominant_software_version = Batch.last_scored(@network).software_version
 
     network_stat = ClusterStat.find_or_create_by(network: @network)
     network_stat.update(
-      total_active_stake: total_active_stake,
+      total_active_stake: validator_history_stats.total_active_stake,
       software_version: dominant_software_version,
       validator_count: validators_total,
       nodes_count: nodes_total,
-      root_distance: report[:root_distance],
-      vote_distance: report[:vote_distance],
-      skipped_slots: report[:skipped_slots],
-      skipped_votes: report[:skipped_votes_percent]
+      root_distance: validator_score.root_distance_stats,
+      vote_distance: validator_score.vote_distance_stats,
+      skipped_slots: validator_block_history.skipped_slot_stats,
+      skipped_votes: vote_account_history.skipped_votes_stats
     )
   end
 
   private
 
-  def report
-    @report ||= Report.where(name: "report_cluster_stats", network: @network).last.payload.deep_symbolize_keys
+  def validator_history_stats
+    Stats::ValidatorHistory.new(@network, @batch_uuid)
+  end
+
+  def vote_account_history
+    Stats::VoteAccountHistory.new(@network, @batch_uuid)
+  end
+
+  def validator_block_history
+    Stats::ValidatorBlockHistory.new(@network, @batch_uuid)
+  end
+
+  def validator_score
+    @validator_score ||= Stats::ValidatorScore.new(@network, @batch_uuid)
   end
 end

--- a/test/controllers/cluster_stats_controller_test.rb
+++ b/test/controllers/cluster_stats_controller_test.rb
@@ -61,19 +61,8 @@ class ClusterStatsControllerTest < ActionDispatch::IntegrationTest
     top_skipped_slot_percent =
       data[:validator_block_histories].map(&:skipped_slot_percent_moving_average)
                                       .sort.reverse
-    skipped_votes_stats =
-      { min: 0.3518806943896684, max: 0.3518806943896684, median: 0.3518806943896684,
-        average: 0.35188069438966835, best: 0.3518806943896684 }
     skipped_vote_moving_average_stats =
       { min: 0.3519e0.to_s, max: 0.3519e0.to_s, median: 0.3519e0.to_s, average: 0.3519e0.to_s}
-
-    # root_distance_history, vote_distance_stats for each factored validator
-    # is [1,2,3,4,5] and we use averages (which equals to 3) of root
-    # distance for statistics
-    root_distance_stats = { min: 3, max: 3, median: 3, average: 3 }
-    vote_distance_stats = { min: 3, max: 3, median: 3, average: 3 }
-    skipped_slot_stats = { min: 0.25.to_s, max: 0.25.to_s, median: 0.25.to_s, average: 0.25.to_s }
-
 
     assert_equal stats[:batch_uuid],
                  Batch.last_scored(network).uuid
@@ -87,16 +76,8 @@ class ClusterStatsControllerTest < ActionDispatch::IntegrationTest
                  stats[:top_vote_distance_validators].map(&:first), "Top Vote Distance"
     assert_equal top_skipped_slot_percent.map(&:to_s), 
                  stats[:top_skipped_slot_validators].map(&:first), "Top Skipped Slot"
-    assert_equal skipped_votes_stats, 
-                 stats[:skipped_votes_percent], "Skipped Vote Stats"
     assert_equal skipped_vote_moving_average_stats, 
                  stats[:skipped_votes_percent_moving_average] , "skipped_vote_moving_average_stats"
-    assert_equal root_distance_stats, 
-                 stats[:root_distance], "root_distance_stats"
-    assert_equal vote_distance_stats, 
-                 stats[:vote_distance], "vote_distance_stats"
-    assert_equal skipped_slot_stats, 
-                 stats[:skipped_slots], "skipped_slot_stats"
   end
 
   def prepare_data_for_cluster_stats(network)


### PR DESCRIPTION
#### What's this PR do?
PR removes the cluster stats model attributes from the report logic.

#### How should this be manually tested?
* run tests
* verify if skipped and distance components on the homepage update with correct data
* investigate the report_cluster_stats, if it contains duplicated data

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183637326)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
