### PR TITLE
183639579 - reduce leader component intervals

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -120,6 +120,7 @@ namespace :deamons do
           execute :systemctl, '--user', :start, :gather_vote_account_details
           execute :systemctl, '--user', :start, :process_ping_thing
           execute :systemctl, '--user', :start, :front_stats_update
+          execute :systemctl, '--user', :start, :leader_stats_update
         end
       end
     end
@@ -137,6 +138,7 @@ namespace :deamons do
           execute :systemctl, '--user', :stop, :gather_vote_account_details
           execute :systemctl, '--user', :stop, :process_ping_thing
           execute :systemctl, '--user', :stop, :front_stats_update
+          execute :systemctl, '--user', :stop, :leader_stats_update
         end
       end
     end
@@ -154,6 +156,7 @@ namespace :deamons do
           execute :systemctl, '--user', :restart, :gather_vote_account_details
           execute :systemctl, '--user', :restart, :process_ping_thing
           execute :systemctl, '--user', :restart, :front_stats_update
+          execute :systemctl, '--user', :restart, :leader_stats_update
         end
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -156,7 +156,7 @@ namespace :deamons do
           execute :systemctl, '--user', :restart, :gather_vote_account_details
           execute :systemctl, '--user', :restart, :process_ping_thing
           execute :systemctl, '--user', :restart, :front_stats_update
-          execute :systemctl, '--user', :restart, :leader_stats_update
+          # execute :systemctl, '--user', :restart, :leader_stats_update
         end
       end
     end

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -11,7 +11,7 @@ module LeaderStatsHelper
       [network, leaders_for_network(network)]
     end.to_h
   end
-q
+
   private
 
   def leaders_for_network(network)

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module LeaderStatsHelper  
+  LEADERS_LIMIT = 6
+  FETCHED_LEADERS_LIMIT = 20
+  MAINNET = "mainnet"
+  NETWORKS = [MAINNET, "testnet"].freeze
+
+  def all_leaders
+    NETWORKS.map do |network|
+      [network, leaders_for_network(network)]
+    end.to_h
+  end
+q
+  private
+
+  def leaders_for_network(network)
+    client = solana_client(network)
+    current_slot = client.get_slot.result
+    leader_accounts = client.get_slot_leaders(current_slot, FETCHED_LEADERS_LIMIT).result
+    leaders = Validator.where(account: leader_accounts)
+
+    leaders_data(leaders).take(LEADERS_LIMIT)
+  end
+
+  def leaders_data(leaders)
+    leaders.map do |leader|
+      { name: leader.name, avatar_url: leader.avatar_url, account: leader.account }
+    end
+  end
+
+  def solana_client(network)
+    network == MAINNET ? mainnet_client : testnet_client
+  end
+
+  def mainnet_client
+    SolanaRpcClient.new.mainnet_client
+  end
+
+  def testnet_client
+    SolanaRpcClient.new.testnet_client
+  end
+end

--- a/daemons/leader_stats_update.service
+++ b/daemons/leader_stats_update.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=update leaders component stats with action cable
+After=syslog.target network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/deploy/validators.app/current/
+
+ExecStart=/usr/bin/bundle exec /usr/bin/ruby daemons/leader_stats_update_daemon.rb
+
+UMask=0002
+
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+# Environment=MALLOC_ARENA_MAX=2
+# Environment=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+
+Environment=RAILS_ENV=production
+
+# if we crash, restart
+RestartSec=10
+Restart=always
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# Limits
+LimitNOFILE=infinity
+LimitMEMLOCK=infinity
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=leader_stats_update_daemon
+
+[Install]
+WantedBy=default.target

--- a/daemons/leader_stats_update_daemon.rb
+++ b/daemons/leader_stats_update_daemon.rb
@@ -1,40 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "../config/environment"
+require_relative "concerns/leader_stats_helper"
 
-@leaders_limit = 6
-@fetched_leaders_limit = 20
-@mainnet = "mainnet"
-@networks = [@mainnet, "testnet"].freeze
+include LeaderStatsHelper
+
 sleep_time = 2 # seconds
-
-def all_leaders
-  @networks.map do |network|
-    [network, leaders_for_network(network)]
-  end.to_h
-end
-
-def leaders_for_network(network)
-  client = solana_client(network)
-  current_slot = client.get_slot.result
-  leader_accounts = client.get_slot_leaders(current_slot, @fetched_leaders_limit).result
-  leaders = Validator.where(account: leader_accounts)
-
-  leaders_data(leaders).take(@leaders_limit)
-end
-
-def leaders_data(leaders)
-  leaders.map do |leader|
-    { name: leader.name, avatar_url: leader.avatar_url, account: leader.account }
-  end
-end
-
-def solana_client(network)
-  network == @mainnet ? @mainnet_client : @testnet_client
-end
-
-@mainnet_client = SolanaRpcClient.new.mainnet_client
-@testnet_client = SolanaRpcClient.new.testnet_client
 
 loop do
   begin

--- a/daemons/leader_stats_update_daemon.rb
+++ b/daemons/leader_stats_update_daemon.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../config/environment"
+
+@leaders_limit = 6
+@fetched_leaders_limit = 20
+@mainnet = "mainnet"
+@networks = [@mainnet, "testnet"].freeze
+sleep_time = 2 # seconds
+
+def all_leaders
+  @networks.map do |network|
+    [network, leaders_for_network(network)]
+  end.to_h
+end
+
+def leaders_for_network(network)
+  client = solana_client(network)
+  current_slot = client.get_slot.result
+  leader_accounts = client.get_slot_leaders(current_slot, @fetched_leaders_limit).result
+  leaders = Validator.where(account: leader_accounts)
+
+  leaders_data(leaders).take(@leaders_limit)
+end
+
+def leaders_data(leaders)
+  leaders.map do |leader|
+    { name: leader.name, avatar_url: leader.avatar_url, account: leader.account }
+  end
+end
+
+def solana_client(network)
+  network == @mainnet ? @mainnet_client : @testnet_client
+end
+
+@mainnet_client = SolanaRpcClient.new.mainnet_client
+@testnet_client = SolanaRpcClient.new.testnet_client
+
+loop do
+  begin
+    leaders = all_leaders
+    print leaders
+    ActionCable.server.broadcast("leaders_channel", leaders)
+    sleep(sleep_time)
+  rescue => e
+    puts e
+    puts e.backtrace
+    sleep(sleep_time)
+    next
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
PR reduces the interval for fetching data of leaders component.

#### How should this be manually tested?
* restart the `daemons/front_stats_update_daemon.rb`
* run the `daemons/leader_stats_update_daemon.rb`

Verify if the homepage is updated correctly and includes a valid data.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183639579)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
