### PR TITLE
183651841 Fix current leader component

### DIFF
--- a/app/javascript/packs/leaders/leaders_stats_component_template.vue
+++ b/app/javascript/packs/leaders/leaders_stats_component_template.vue
@@ -20,7 +20,7 @@
           </div>
         </div>
 
-        <div v-if="current_leader">
+        <div v-if="next_leaders.length > 0">
           <h2 class="h6 card-heading-left">Next Leaders</h2>
           <div class="d-flex flex-wrap gap-3">
             <a v-for="leader in next_leaders"

--- a/app/javascript/packs/leaders/leaders_stats_component_template.vue
+++ b/app/javascript/packs/leaders/leaders_stats_component_template.vue
@@ -5,6 +5,7 @@
         <div class="mb-4">
           <h2 class="h5 card-heading-left">Leader</h2>
           <span class="text-muted" v-if="!current_leader">loading...</span>
+
           <div class="d-flex flex-wrap gap-3" v-if="current_leader">
             <a :href="validator_details_link(current_leader.account)"
                title="Go to validator details." target="_blank">

--- a/app/javascript/packs/leaders/leaders_stats_component_template.vue
+++ b/app/javascript/packs/leaders/leaders_stats_component_template.vue
@@ -42,7 +42,7 @@
     data() {
       return {
         current_leader: null,
-        next_leaders: []
+        next_leaders: [],
       }
     },
     channels: {
@@ -51,8 +51,8 @@
         rejected() { },
         received(data) {
           data = data[this.network];
-          this.current_leader = data.shift();
-          this.next_leaders = data;
+          this.current_leader = data.current_leader;
+          this.next_leaders = data.next_leaders;
         },
         disconnected() { }
       }

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module LeaderStatsHelper
-  LEADERS_LIMIT = 12
+  LEADERS_LIMIT = 9
   MAINNET = "mainnet"
   NETWORKS = [MAINNET, "testnet"].freeze
 

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-module LeaderStatsHelper  
-  LEADERS_LIMIT = 6
-  FETCHED_LEADERS_LIMIT = 20
+module LeaderStatsHelper
+  LEADERS_LIMIT = 12
   MAINNET = "mainnet"
   NETWORKS = [MAINNET, "testnet"].freeze
 
@@ -17,10 +16,14 @@ module LeaderStatsHelper
   def leaders_for_network(network)
     client = solana_client(network)
     current_slot = client.get_slot.result
-    leader_accounts = client.get_slot_leaders(current_slot, FETCHED_LEADERS_LIMIT).result
-    leaders = Validator.where(account: leader_accounts)
-
-    leaders_data(leaders).take(LEADERS_LIMIT)
+    leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
+    leaders = Validator.where(account: leader_accounts, network: network)
+                       .select(:name, :account, :avatar_url)
+    leaders = leaders_data(leaders)
+    {
+      current_leader: leaders.shift,
+      next_leaders: leaders
+    }
   end
 
   def leaders_data(leaders)

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -15,14 +15,23 @@ module LeaderStatsHelper
 
   def leaders_for_network(network)
     client = solana_client(network)
-    current_slot = client.get_slot.result
-    leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
-    leaders = Validator.where(account: leader_accounts, network: network)
-                       .select(:name, :account, :avatar_url)
-    leaders = leaders_data(leaders)
+    # current_slot = client.get_slot.result
+    # leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
+    # leaders = Validator.where(account: leader_accounts, network: network)
+    #                    .select(:name, :account, :avatar_url)
+    # leaders = leaders_data(leaders)
+    #
+    # {
+    #   current_leader: leaders.shift,
+    #   next_leaders: leaders
+    # }
+
+    leader_account = client.get_slot_leader.result
+    leader = Validator.where(account: leader_account, network: network).select(:name, :account, :avatar_url)
+    leader = leaders_data(leader)
     {
-      current_leader: leaders.shift,
-      next_leaders: leaders
+      current_leader: leader.first,
+      next_leaders: []
     }
   end
 

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -15,23 +15,18 @@ module LeaderStatsHelper
 
   def leaders_for_network(network)
     client = solana_client(network)
-    # current_slot = client.get_slot.result
-    # leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
-    # leaders = Validator.where(account: leader_accounts, network: network)
-    #                    .select(:name, :account, :avatar_url)
-    # leaders = leaders_data(leaders)
-    #
-    # {
-    #   current_leader: leaders.shift,
-    #   next_leaders: leaders
-    # }
+    current_slot = client.get_slot.result
 
-    leader_account = client.get_slot_leader.result
-    leader = Validator.where(account: leader_account, network: network).select(:name, :account, :avatar_url)
-    leader = leaders_data(leader)
+    current_leader_account = client.get_slot_leader.result
+    current_leader = Validator.where(account: current_leader_account, network: network).select(:name, :account, :avatar_url)
+
+    leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
+    next_leaders = Validator.where(account: leader_accounts, network: network)
+                            .select(:name, :account, :avatar_url)
+
     {
-      current_leader: leader.first,
-      next_leaders: []
+      current_leader: leaders_data(current_leader).first,
+      next_leaders: leaders_data(next_leaders)
     }
   end
 

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -23,7 +23,8 @@ module LeaderStatsHelper
     leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
     next_leaders = Validator.where(account: leader_accounts, network: network)
                             .select(:name, :account, :avatar_url)
-
+                            .sort_by{ |v| leader_accounts.index(v.account) }
+    
     {
       current_leader: leaders_data(current_leader).first,
       next_leaders: leaders_data(next_leaders)

--- a/daemons/concerns/leader_stats_helper.rb
+++ b/daemons/concerns/leader_stats_helper.rb
@@ -15,19 +15,20 @@ module LeaderStatsHelper
 
   def leaders_for_network(network)
     client = solana_client(network)
+
     current_slot = client.get_slot.result
+    leaders_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
 
-    current_leader_account = client.get_slot_leader.result
-    current_leader = Validator.where(account: current_leader_account, network: network).select(:name, :account, :avatar_url)
-
-    leader_accounts = client.get_slot_leaders(current_slot, LEADERS_LIMIT).result
-    next_leaders = Validator.where(account: leader_accounts, network: network)
+    leaders_data = Validator.where(account: leaders_accounts, network: network)
                             .select(:name, :account, :avatar_url)
-                            .sort_by{ |v| leader_accounts.index(v.account) }
-    
+                            .limit(3)
+                            .sort_by{ |v| leaders_accounts.index(v.account) }
+    leaders = leaders_data(leaders_data)
+    current_leader = leaders.shift
+
     {
-      current_leader: leaders_data(current_leader).first,
-      next_leaders: leaders_data(next_leaders)
+      current_leader: current_leader,
+      next_leaders: leaders
     }
   end
 

--- a/daemons/leader_stats_update_daemon.rb
+++ b/daemons/leader_stats_update_daemon.rb
@@ -5,7 +5,7 @@ require_relative "concerns/leader_stats_helper"
 
 include LeaderStatsHelper
 
-sleep_time = 1 # seconds
+sleep_time = 0.6 # seconds
 
 loop do
   begin

--- a/daemons/leader_stats_update_daemon.rb
+++ b/daemons/leader_stats_update_daemon.rb
@@ -5,12 +5,11 @@ require_relative "concerns/leader_stats_helper"
 
 include LeaderStatsHelper
 
-sleep_time = 2 # seconds
+sleep_time = 1 # seconds
 
 loop do
   begin
     leaders = all_leaders
-    print leaders
     ActionCable.server.broadcast("leaders_channel", leaders)
     sleep(sleep_time)
   rescue => e

--- a/test/daemons/leader_stats_helper_test.rb
+++ b/test/daemons/leader_stats_helper_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require Rails.root.join("daemons", "concerns", "leader_stats_helper")
+
+class LeaderStatsHelperTest < ActiveSupport::TestCase
+  include LeaderStatsHelper
+  include VcrHelper
+
+  setup do
+    @validator = create(:validator, network: "testnet")
+    ["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ", "ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc", "FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"].each do |account|
+      create(:validator, network: "testnet", account: account)
+    end
+    @vcr_namespace ||= File.join("daemons", "leader_stats_helper_test")
+  end
+
+  test "#all_leaders returns data for both networks" do
+    vcr_cassette(@vcr_namespace, __method__) do
+      result = all_leaders
+      assert result.keys.include? "mainnet"
+      assert result.keys.include? "testnet"
+    end
+  end
+
+  test "#leaders_for_network returns correct leaders" do
+    vcr_cassette(@vcr_namespace, __method__) do
+      result = all_leaders
+
+      assert_equal "9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ", result["testnet"][:current_leader][:account]
+      assert_equal "ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc", result["testnet"][:next_leaders].first[:account]
+      assert_equal "FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE", result["testnet"][:next_leaders].second[:account]
+    end
+  end
+end

--- a/test/daemons/leader_stats_helper_test.rb
+++ b/test/daemons/leader_stats_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require Rails.root.join("daemons", "concerns", "leader_stats_helper")
 
@@ -7,7 +9,8 @@ class LeaderStatsHelperTest < ActiveSupport::TestCase
 
   setup do
     @validator = create(:validator, network: "testnet")
-    ["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ", "ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc", "FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"].each do |account|
+    ["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ", "ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc",
+     "FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"].each do |account|
       create(:validator, network: "testnet", account: account)
     end
     @vcr_namespace ||= File.join("daemons", "leader_stats_helper_test")

--- a/test/vcr_cassettes/daemons/leader_stats_helper_test/test__all_leaders_returns_data_for_both_networks.yml
+++ b/test/vcr_cassettes/daemons/leader_stats_helper_test/test__all_leaders_returns_data_for_both_networks.yml
@@ -86,7 +86,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"jsonrpc":"2.0","result":["5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk"],"id":58461}
+      string: '{"jsonrpc":"2.0","result":["5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk"],"id":58461}
 
         '
   recorded_at: Mon, 31 Oct 2022 21:39:29 GMT
@@ -172,7 +172,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"jsonrpc":"2.0","result":["J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM"],"id":56165}
+      string: '{"jsonrpc":"2.0","result":["J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM"],"id":56165}
 
         '
   recorded_at: Mon, 31 Oct 2022 21:39:30 GMT

--- a/test/vcr_cassettes/daemons/leader_stats_helper_test/test__all_leaders_returns_data_for_both_networks.yml
+++ b/test/vcr_cassettes/daemons/leader_stats_helper_test/test__all_leaders_returns_data_for_both_networks.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.rpcpool.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":58461,"method":"getSlot"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rpcpool.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://user:brian
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:39:29 GMT
+      X-Rpc-Node:
+      - lb-ams2
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":158539028,"id":58461}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:39:29 GMT
+- request:
+    method: post
+    uri: https://api.rpcpool.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":58461,"method":"getSlotLeaders","params":[158539028,12]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rpcpool.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://user:brian
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:39:29 GMT
+      X-Rpc-Node:
+      - lb-ams2
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":["5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","5JQLBUVAH597sUrcYiggqbmS4NyxfafCsw1nFJw4vxYD","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fxsn579uS4xAWHWNR9v4A3m2upUnACYcDuhKmL2fbRmu","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk","Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk"],"id":58461}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:39:29 GMT
+- request:
+    method: post
+    uri: https://api.testnet.solana.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":56165,"method":"getSlot"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.testnet.solana.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://authenticated-user
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:39:29 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":160625120,"id":56165}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:39:29 GMT
+- request:
+    method: post
+    uri: https://api.testnet.solana.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":56165,"method":"getSlotLeaders","params":[160625120,12]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.testnet.solana.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://authenticated-user
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:39:30 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":["J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","8bn2BhTzfNEQoMyEPJ2q58hFzQY8GxPkLRFWHMWksLet","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM","HSKW3uvKvd6spwFSdxzbxH87os134SFGJrLj4uWCy4qM"],"id":56165}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:39:30 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/daemons/leader_stats_helper_test/test__leaders_for_network_returns_correct_leaders.yml
+++ b/test/vcr_cassettes/daemons/leader_stats_helper_test/test__leaders_for_network_returns_correct_leaders.yml
@@ -172,7 +172,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"jsonrpc":"2.0","result":["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"],"id":50138}
+      string: '{"jsonrpc":"2.0","result":["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"],"id":50138}
 
         '
   recorded_at: Mon, 31 Oct 2022 21:30:44 GMT

--- a/test/vcr_cassettes/daemons/leader_stats_helper_test/test__leaders_for_network_returns_correct_leaders.yml
+++ b/test/vcr_cassettes/daemons/leader_stats_helper_test/test__leaders_for_network_returns_correct_leaders.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.rpcpool.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":72560,"method":"getSlot"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rpcpool.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://user:brian
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:30:27 GMT
+      X-Rpc-Node:
+      - lb-ams2
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":158538024,"id":72560}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:30:27 GMT
+- request:
+    method: post
+    uri: https://api.rpcpool.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":72560,"method":"getSlotLeaders","params":[158538024,12]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rpcpool.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://user:brian
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:30:27 GMT
+      X-Rpc-Node:
+      - lb-ams2
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":["3afBZYTabgqgrGd2HuvqPLC62VpZBpjVMhEHjauZpk7s","3afBZYTabgqgrGd2HuvqPLC62VpZBpjVMhEHjauZpk7s","3afBZYTabgqgrGd2HuvqPLC62VpZBpjVMhEHjauZpk7s","3afBZYTabgqgrGd2HuvqPLC62VpZBpjVMhEHjauZpk7s","B5GABybkqGaxxFE6bcN6TEejDF2tuz6yREciLhvvKyMp","B5GABybkqGaxxFE6bcN6TEejDF2tuz6yREciLhvvKyMp","B5GABybkqGaxxFE6bcN6TEejDF2tuz6yREciLhvvKyMp","B5GABybkqGaxxFE6bcN6TEejDF2tuz6yREciLhvvKyMp","5UUWU7TjkXEg5i8ddXtiuF98QoT7gvHNuJ6K2rVedXnr","5UUWU7TjkXEg5i8ddXtiuF98QoT7gvHNuJ6K2rVedXnr","5UUWU7TjkXEg5i8ddXtiuF98QoT7gvHNuJ6K2rVedXnr","5UUWU7TjkXEg5i8ddXtiuF98QoT7gvHNuJ6K2rVedXnr"],"id":72560}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:30:28 GMT
+- request:
+    method: post
+    uri: https://api.testnet.solana.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":50138,"method":"getSlot"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.testnet.solana.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://authenticated-user
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:30:44 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":160623862,"id":50138}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:30:44 GMT
+- request:
+    method: post
+    uri: https://api.testnet.solana.com/
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":50138,"method":"getSlotLeaders","params":[160623862,12]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.testnet.solana.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      - origin
+      Access-Control-Allow-Methods:
+      - OPTIONS, POST
+      Access-Control-Allow-Origin:
+      - http://authenticated-user
+      Access-Control-Max-Age:
+      - '86400'
+      Date:
+      - Mon, 31 Oct 2022 21:30:44 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"jsonrpc":"2.0","result":["9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","9MRUTN19MtA1matBH4ddgpS14mPAdeCoFnsLkaLxFeBQ","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","ACPgwKgncgFAm8goFj4dJ5e5mcH3tRy646f7zYPaWEzc","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE","FbWq9mwUQRNVCAUdcECF5yhdwABmcnsZ6a6zpixeKuQE"],"id":50138}
+
+        '
+  recorded_at: Mon, 31 Oct 2022 21:30:44 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### What's this PR do?
- Fixes current leader component: 
  - tweaks query to pull only needed data, 
  - fixes query to use existing indexes,
  - fixes results order to match leaders order in schedule

#### How should this be manually tested?
- Locally: run `rails r daemons/leader_stats_update_daemon.rb` and confirm that leaders visible in leaders component on /home-new are processed one by one, not mixed anymore
- On staging: go to https://stage.validators.app/home-new and check leaders component

#### What are the relevant tickets?
-[ URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183651841)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
