### PR TITLE
183654712 - increase the time range ago in commission history view

### DIFF
--- a/app/queries/commission_history_query.rb
+++ b/app/queries/commission_history_query.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CommissionHistoryQuery
+  TIME_RANGE_AGO = 60.days.ago
+
   CH_FIELDS = %w[
     created_at
     commission_before
@@ -20,7 +22,7 @@ class CommissionHistoryQuery
 
   def initialize(options)
     @network = options.fetch(:network, 'testnet')
-    @time_from = options.fetch(:time_from, 30.days.ago) || 30.days.ago
+    @time_from = options.fetch(:time_from, TIME_RANGE_AGO) || TIME_RANGE_AGO
     @time_to = options.fetch(:time_to, DateTime.now) || DateTime.now
     @time_range = @time_from..@time_to
     @sort_by = options.fetch(:sort_by, 'timestamp_desc') || 'timestamp_desc'

--- a/test/queries/commission_history_query_test.rb
+++ b/test/queries/commission_history_query_test.rb
@@ -14,7 +14,7 @@ class CommissionHistoryQueryTest < ActiveSupport::TestCase
     end
 
     create(:commission_history, validator: val1)
-    create(:commission_history, validator: val2, created_at: 32.days.ago)
+    create(:commission_history, validator: val2, created_at: 62.days.ago)
   end
 
   test 'commission_history_query \
@@ -32,7 +32,7 @@ class CommissionHistoryQueryTest < ActiveSupport::TestCase
         should include results from correct validators' do
     result = CommissionHistoryQuery.new(
       network: 'testnet',
-      time_from: 33.day.ago,
+      time_from: 63.day.ago,
       time_to: DateTime.now
     ).by_query('acc2')
 


### PR DESCRIPTION
#### What's this PR do?
Increase time range for commission histories view. 

#### How should this be manually tested?
Enter the /commission-changes page and check if the results date range is within 60 days.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183654712)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
