### PR TITLE
183730419 - add pythnet to gather vote daemon

### DIFF
--- a/app/services/solana_rpc_client.rb
+++ b/app/services/solana_rpc_client.rb
@@ -26,7 +26,7 @@ class SolanaRpcClient
   def network_client(network)
     raise InvalidNetwork unless ::NETWORKS.include?(network)
 
-    network_cluster = Rails.application.credentials.solana["#{network}_urls".to_sym].first
+    network_cluster = NETWORK_URLS[network].first
     # Reset the client when the network is different from the one already initialized
     if @cluster != network_cluster
       @cluster = network_cluster

--- a/config/initializers/solana_networks.rb
+++ b/config/initializers/solana_networks.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
 NETWORKS = %w[mainnet testnet pythnet].freeze
+NETWORK_URLS = {
+  mainnet: Rails.application.credentials.solana[:mainnet_urls],
+  testnet: Rails.application.credentials.solana[:testnet_urls],
+  pythnet: Rails.application.credentials.solana[:pythnet_urls]
+}.stringify_keys.freeze

--- a/daemons/gather_vote_account_details_daemon.rb
+++ b/daemons/gather_vote_account_details_daemon.rb
@@ -7,16 +7,9 @@ class SkipAndSleep < StandardError; end
 begin
   loop do
     NETWORKS.each do |network|
-      config_urls =
-        case network
-        when "mainnet" then Rails.application.credentials.solana[:mainnet_urls]
-        when "testnet" then Rails.application.credentials.solana[:testnet_urls]
-        when "pythnet" then Rails.application.credentials.solana[:pythnet_urls]
-        end
-
       Gatherers::VoteAccountDetailsService.new(
         network: network,
-        config_urls: config_urls
+        config_urls: NETWORK_URLS[network]
       ).call
     end
   rescue SkipAndSleep => e

--- a/daemons/gather_vote_account_details_daemon.rb
+++ b/daemons/gather_vote_account_details_daemon.rb
@@ -6,12 +6,13 @@ class SkipAndSleep < StandardError; end
 
 begin
   loop do
-    %w[mainnet testnet].each do |network|
-      config_urls = if network == 'testnet'
-        Rails.application.credentials.solana[:testnet_urls]
-      else
-        Rails.application.credentials.solana[:mainnet_urls]
-      end
+    NETWORKS.each do |network|
+      config_urls =
+        case network
+        when "mainnet" then Rails.application.credentials.solana[:mainnet_urls]
+        when "testnet" then Rails.application.credentials.solana[:testnet_urls]
+        when "pythnet" then Rails.application.credentials.solana[:pythnet_urls]
+        end
 
       Gatherers::VoteAccountDetailsService.new(
         network: network,

--- a/dev/gather_vote_account_details_force_update.rb
+++ b/dev/gather_vote_account_details_force_update.rb
@@ -11,15 +11,10 @@ end
 %w[mainnet testnet].each do |network|
   puts "getting #{network} validators"
   puts "----------------------------"
-  config_urls = if network == "testnet"
-    Rails.application.credentials.solana[:testnet_urls]
-  else
-    Rails.application.credentials.solana[:mainnet_urls]
-  end
 
   Gatherers::VoteAccountDetailsService.new(
     network: network,
-    config_urls: config_urls,
+    config_urls: NETWORK_URLS[network],
     always_update: true
   ).call
 end

--- a/script/gather_stake_accounts.rb
+++ b/script/gather_stake_accounts.rb
@@ -6,7 +6,7 @@ require 'stake_logic'
 include StakeLogic
 NETWORKS.each do |network|
   payload = {
-    config_urls: Rails.application.credentials.solana["#{network}_urls".to_sym],
+    config_urls: NETWORK_URLS[network],
     network: network
   }
 

--- a/script/one_time_scripts/reduce_validators_with_invalid_config.rb
+++ b/script/one_time_scripts/reduce_validators_with_invalid_config.rb
@@ -6,7 +6,7 @@ include SolanaLogic
 
 NETWORKS.each do |network|
   payload = {
-    config_urls: Rails.application.credentials.solana["#{network}_urls".to_sym],
+    config_urls: NETWORK_URLS[network],
     network: network
   }
 

--- a/script/update_gossip_nodes.rb
+++ b/script/update_gossip_nodes.rb
@@ -8,7 +8,7 @@ NETWORKS.each do |network|
   logger = Logger.new("#{Rails.root}/log/gossip_nodes_#{network}.log")
 
   payload = {
-    config_urls: Rails.application.credentials.solana["#{network}_urls".to_sym],
+    config_urls: NETWORK_URLS[network],
     network: network
   }
 

--- a/script/validators_get_info.rb
+++ b/script/validators_get_info.rb
@@ -8,7 +8,7 @@ include SolanaLogic
 
 NETWORKS.each do |network|
   payload = {
-    config_urls: Rails.application.credentials.solana["#{network}_urls".to_sym],
+    config_urls: NETWORK_URLS[network],
     network: network
   }
 


### PR DESCRIPTION
#### What's this PR do?
PR adds pythnet in to the gather vote account details daemon.

#### How should this be manually tested?
- ticket explicitly concerns the rake task - `daemons/gather_vote_account_details_daemon.rb` so please execute it and check for pythnet's vote account details.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183730419)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
