### PR TITLE
183888702 - perform notify_users after commission history was saved

### DIFF
--- a/app/models/commission_history.rb
+++ b/app/models/commission_history.rb
@@ -27,7 +27,21 @@
 class CommissionHistory < ApplicationRecord
   belongs_to :validator
 
+  after_commit :notify_users, on: :create
+
   def rising?
     commission_after.to_i > commission_before.to_i
+  end
+
+  private
+
+  def notify_users
+    validator.watchers.each do |watcher|
+      CommissionHistoryMailer.commission_change_info(
+        user: watcher,
+        validator: validator,
+        commission: self
+      ).deliver_later
+    end
   end
 end

--- a/app/services/create_commission_history_service.rb
+++ b/app/services/create_commission_history_service.rb
@@ -10,7 +10,6 @@ class CreateCommissionHistoryService
   # otherwise it returns false
   def call
     commission_change = create_commission
-    notify_users(commission_change)
   rescue StandardError => e
     OpenStruct.new({ success?: false, error: e })
   else
@@ -45,15 +44,5 @@ class CreateCommissionHistoryService
 
   def recent_epoch_completion
     ((recent_epoch.slot_index / recent_epoch.slots_in_epoch.to_f) * 100).round(2)
-  end
-
-  def notify_users(commission_change)
-    @score.validator.watchers.each do |watcher|
-      CommissionHistoryMailer.commission_change_info(
-        user: watcher,
-        validator: @score.validator,
-        commission: commission_change
-      ).deliver_later
-    end
   end
 end

--- a/test/mailers/commission_history_mailer_test.rb
+++ b/test/mailers/commission_history_mailer_test.rb
@@ -11,6 +11,7 @@ class CommissionHistoryMailerTest < ActiveSupport::TestCase
     @user = create(:user)
 
     create(:user_watchlist_element, user: @user, validator: @validator)
+    @validator.reload
   end
 
   test "#commission_change_info sends email to a watcher" do

--- a/test/models/commission_history_test.rb
+++ b/test/models/commission_history_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class CommissionHistoryTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+
   test 'rising? \
         when commission before is smaller than after\
         should return true' do
@@ -17,5 +19,14 @@ class CommissionHistoryTest < ActiveSupport::TestCase
     c = create(:commission_history, commission_before: 20, commission_after: 10)
 
     refute c.rising?
+  end
+
+  test "execute CommissionHistoryMailer after commit" do
+    user = create(:user)
+    validator = create(:validator)
+    create(:user_watchlist_element, user: user, validator: validator)
+    commission_history = create(:commission_history, validator: validator)
+
+    assert_equal ActiveJob::Base.queue_adapter.enqueued_jobs[0][:args][0], "CommissionHistoryMailer"
   end
 end


### PR DESCRIPTION
#### What's this PR do?
PR fixes error regarding CommissionHistory no found. It makes sending a CommissionHistoryMailer after the CommissionHistory is created.

#### How should this be manually tested?
It would be hard to replicate the AppSignal issue. Before changes the CommissionHistory hasn't been created (transaction commited) before the CommissionHistoryMailer was executed. Hereby that the "Couldn't find CommissionHistory" was been raising.

You can test `CreateCommissionHistoryService` by the following:
- look for `ValidatorScoreV1` record with `validator.watchers` included.
- run `#{validator_score_v1}.create_commission_history`

Console output should include `ActionMailer::MailDeliveryJob` result. 

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183888702)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
