### PR TITLE
183882661 - enable turbolinks on sol prices page

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -29,7 +29,7 @@
         <li class="nav-item" data-turbolinks="false">
           <%= link_to 'Ping Thing', ping_things_path(network: params[:network]), class: 'nav-link' %>
         </li>
-        <li class="nav-item" data-turbolinks="true">
+        <li class="nav-item">
           <%= link_to 'Sol Prices', sol_prices_url(exchange: SolPrice::EXCHANGES[0], filtering: 7), class: 'nav-link' %>
         </li>
         <li class="nav-item">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -29,7 +29,7 @@
         <li class="nav-item" data-turbolinks="false">
           <%= link_to 'Ping Thing', ping_things_path(network: params[:network]), class: 'nav-link' %>
         </li>
-        <li class="nav-item" data-turbolinks="false">
+        <li class="nav-item" data-turbolinks="true">
           <%= link_to 'Sol Prices', sol_prices_url(exchange: SolPrice::EXCHANGES[0], filtering: 7), class: 'nav-link' %>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
#### What's this PR do?
Unfortunately we cannot load vue components on real `turbolinks:load` events. These components are being loaded on `DOMContentLoaded` event instead. 

Notice: if turbolinks data is disabled (at our homepage e.g.) then turbolinks reloads all data, so the events `turbolinks:load` and `DOMContentLoaded` do perform at the same point.

This PR only turns on turbolinks on Sol Prices page.

#### How should this be manually tested?
- check sol prices page if the content is loaded
- at Sol Prices page move to page where turbolinks are activated
- click "back button" and check whether the `<body>` tag has only been changed (`<head>` should stay untouched)

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/183882661)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
