### PR TITLE
184072139 - remove turbolinks for validators

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -14,7 +14,7 @@
         <li class="nav-item">
           <%= link_to 'API Docs', api_documentation_path, class: 'nav-link active' %>
         </li>
-        <li class="nav-item">
+        <li class="nav-item" data-turbolinks="false">
           <%= link_to 'Validators', validators_path(network: params[:network]), class: 'nav-link' %>
         </li>
         <li class="nav-item">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,10 +16,10 @@
       <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav ms-auto">
           <li class="nav-item">
-            <%= link_to "Validators", validators_path(network: params[:network]), class: 'nav-link' %>
+            <%= link_to "Validators", validators_path(network: params[:network]), class: 'nav-link', "data-turbolinks": "false" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Getting Started", faq_path, class: 'nav-link' %>
+            <%= link_to "Getting Started", faq_path, class: 'nav-link', "data-turbolinks": "false" %>
           </li>
           <div id="network-buttons"></div>
         </ul>


### PR DESCRIPTION
#### What's this PR do?
PR fixes navigation to validators from any not-turbolinked page (such as home).

#### How should this be manually tested?
Check if current page is being reloaded before user redirects another page (e.g. clicks Validators link at home page).

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184072139)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
