### PR TITLE
184073409-no-refresh-for-supply-stats

### DIFF
--- a/app/javascript/packs/validators/circulating_supply.vue
+++ b/app/javascript/packs/validators/circulating_supply.vue
@@ -42,7 +42,6 @@
       this.connection = new web3.Connection(this.web3_url);
 
       this.update_circulating_supply();
-      this.set_continuous_supply_update();
     },
     mounted: function(){
       this.$cable.subscribe({
@@ -79,11 +78,6 @@
       },
       percent_of_total_stake() {
         return (parseInt(this.circulating_supply) * 100 / parseInt(this.total_circulating_supply)).toFixed(0);
-      },
-      set_continuous_supply_update() {
-        setInterval(() => {
-          this.update_circulating_supply();
-        }, 5000);
       }
     }
   }


### PR DESCRIPTION
#### What's this PR do?
- Do not refresh total and circulating supply via web3

#### How should this be manually tested?
- go to the home page and check if Stake component works properly

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184073409)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
