### PR TITLE
Add loading image to validator details, charts and table

### DIFF
--- a/app/assets/stylesheets/images.scss
+++ b/app/assets/stylesheets/images.scss
@@ -61,3 +61,10 @@
     border-radius: 5px;
   }
 }
+
+.img-loading {
+  text-align: center;
+  margin: auto;
+  padding-bottom: 50px;
+  img { width: 100px; }
+}

--- a/app/javascript/packs/validators/validator_details.vue
+++ b/app/javascript/packs/validators/validator_details.vue
@@ -2,12 +2,14 @@
   <div>
     <section class="page-header">
       <div class='page-header-name'>
-          <div class="img-circle-private img-circle-medium" v-if="is_private(validator)">
-            <span class='fas fa-users-slash' title="Private Validator"></span>
-          </div>
-          <img :src="validator.avatar_url" class="img-circle-medium" v-else-if="validator.avatar_url" >
-          <img src="https://keybase.io/images/no-photo/placeholder-avatar-180-x-180@2x.png" class="img-circle-medium" v-else >
-        <h1 class="word-break">{{ name_or_account(validator) }}</h1>
+        <div class="img-circle-private img-circle-medium" v-if="is_private(validator)">
+          <span class='fas fa-users-slash' title="Private Validator"></span>
+        </div>
+        <img :src="validator.avatar_url" class="img-circle-medium" v-else-if="validator.avatar_url" >
+        <img src="https://keybase.io/images/no-photo/placeholder-avatar-180-x-180@2x.png" class="img-circle-medium" v-else >
+
+        <h1 class="word-break" v-if="is_loading_validator">loading...</h1>
+        <h1 class="word-break" v-else>{{ name_or_account(validator) }}</h1>
       </div>
 
       <div class="d-flex justify-content-between flex-wrap gap-3">

--- a/app/javascript/packs/validators/validator_details.vue
+++ b/app/javascript/packs/validators/validator_details.vue
@@ -56,7 +56,11 @@
             <h2 class="h4 card-heading">Validator Details</h2>
           </div>
 
-          <table class='table table-block-sm mb-0'>
+          <div class="img-loading" v-if="is_loading_validator">
+            <img v-bind:src="loading_image" width="100">
+          </div>
+
+          <table class="table table-block-sm mb-0" v-if="!is_loading_validator">
             <tbody>
               <tr>
                 <td class="column-lg"><strong>Name:</strong></td>
@@ -105,7 +109,12 @@
           <div class="card-content pb-0">
             <h2 class="h4 card-heading">Validator Details</h2>
           </div>
-          <table class='table table-block-sm mb-0'>
+
+          <div class="img-loading" v-if="is_loading_validator">
+            <img v-bind:src="loading_image" width="100">
+          </div>
+
+          <table class="table table-block-sm mb-0" v-if="!is_loading_validator">
             <tbody>
             <tr>
               <td class="column-lg"><strong>Keybase:</strong></td>
@@ -177,7 +186,11 @@
       Back to All Validators
     </a>
 
-    <div class="row">
+    <div class="img-loading" v-if="is_loading_validator">
+      <img v-bind:src="loading_image" width="100">
+    </div>
+
+    <div class="row" v-if="!is_loading_validator">
       <block-history-chart :root_blocks="root_blocks" v-if="root_blocks.length > 0"></block-history-chart>
       <vote-history-chart :vote_blocks="vote_blocks" v-if="vote_blocks.length > 0"></vote-history-chart>
       <skipped-slots-chart :skipped_slots="skipped_slots" v-if="skipped_slots[1]"></skipped-slots-chart>
@@ -189,7 +202,14 @@
       Back to All Validators
     </a>
 
-    <block-history-table :block_histories="block_histories" :block_history_stats="block_history_stats"></block-history-table>
+    <div class="img-loading" v-if="is_loading_validator">
+      <img v-bind:src="loading_image" width="100">
+    </div>
+
+    <block-history-table :block_histories="block_histories"
+                         :block_history_stats="block_history_stats"
+                          v-if="!is_loading_validator">
+    </block-history-table>
 
     <a :href="go_back_link"
         class="btn btn-sm btn-secondary"
@@ -207,6 +227,7 @@
   import skippedSlotsChart from './components/skipped_slots_chart'
   import blockHistoryTable from './components/block_history_table'
   import axios from 'axios';
+  import loadingImage from 'loading.gif';
 
   axios.defaults.headers.get["Authorization"] = window.api_authorization;
 
@@ -230,7 +251,9 @@
         refresh: null,
         order: null,
         page: null,
-        validator_history: {}
+        validator_history: {},
+        loading_image: loadingImage,
+        is_loading_validator: true
       }
     },
 
@@ -245,6 +268,7 @@
         ctx.block_history_stats = response.data.block_history_stats
         ctx.skipped_slots = JSON.parse(response.data.skipped_slots)
         ctx.validator_history = response.data.validator_history
+        ctx.is_loading_validator = false
       })
 
       let uri = window.location.search.substring(1);


### PR DESCRIPTION
#### What's this PR do?
- Adds loading image to validator details page

#### How should this be manually tested?
- Test on staging - go to validator details page through a link on homepage, on data centers page etc.
- If you want to test locally, you might need to add some timeout to be able to see the difference. Replace the following line `ctx.is_loading_validator = false` in validator_details.vue with:
```
    setTimeout(() => {
      ctx.is_loading_validator = false
    }, "3000")
```

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184214120)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
