### PR TITLE
Filter validators by admin_warning if present

### DIFF
--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -21,7 +21,8 @@ class ValidatorsController < ApplicationController
       sort_order: validators_params[:order],
       limit: @per,
       page: validators_params[:page],
-      query: validators_params[:q]
+      query: validators_params[:q],
+      admin_warning: validators_params[:admin_warning]
     )
 
     @batch = Batch.last_scored(validators_params[:network])
@@ -67,6 +68,6 @@ class ValidatorsController < ApplicationController
   end
 
   def validators_params
-    params.permit(:watchlist, :network, :q, :page, :order)
+    params.permit(:watchlist, :network, :q, :page, :order, :admin_warning)
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Adds optiona admin_warning param 

#### How should this be manually tested?
- Generate some admin_warnings for testing, eg. `Validator.scorable.first(25).each { |v| v.update admin_warning: 'test' } `
- Run the server, go to validators page by a link in top menu. Confirm that default list is unchanged (compared to master branch).
- Now add `&admin_warning=ASD` param to URL at the end (so full URL would look for example like this `http://localhost:3000/validators?locale=en&network=mainnet&admin_warning=true`). Confirm that now you can only see validators with admin_warnings that you edited in point 1.
- Replace param with `&admin_warning=false`. Confirm that now only validators without admin_warnings are listed.
- Confirm that incorrect parameters are ignored, eg. `&admin_warning=ASD`
- Combine with search feature and compare results (you will add admin_warning by hand, it's meant to be hidden)

#### What are the relevant tickets?
- URL to the PivotalTracker ticket

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
