### PR TITLE
184339573-active-validators-commission-tracking

### DIFF
--- a/app/models/epoch_wall_clock.rb
+++ b/app/models/epoch_wall_clock.rb
@@ -23,7 +23,7 @@ class EpochWallClock < ApplicationRecord
 
   scope :by_network, ->(network) { where(network: network).order(epoch: :desc) }
 
-  # after_create :track_commission_changes
+  after_create :track_commission_changes
 
   def track_commission_changes
     if self.network == "mainnet"

--- a/app/models/epoch_wall_clock.rb
+++ b/app/models/epoch_wall_clock.rb
@@ -23,7 +23,7 @@ class EpochWallClock < ApplicationRecord
 
   scope :by_network, ->(network) { where(network: network).order(epoch: :desc) }
 
-  after_create :track_commission_changes
+  # after_create :track_commission_changes
 
   def track_commission_changes
     if self.network == "mainnet"

--- a/app/services/track_commission_changes_service.rb
+++ b/app/services/track_commission_changes_service.rb
@@ -18,7 +18,11 @@ class TrackCommissionChangesService
     commission_history_logger.warn("current_batch #{@current_batch.uuid}, created at: #{@current_batch.created_at}")
     commission_history_logger.warn("previous_batch #{@previous_batch.uuid}, created at: #{@previous_batch.created_at}")
 
-    VoteAccount.includes(:validator).where(network: @network, is_active: true).in_batches(of: 100) do |va_batch|
+    VoteAccount.joins(:validator)
+               .includes(validator: :validator_score_v1)
+               .where(network: @network, is_active: true)
+               .where("validators.is_active = TRUE")
+               .in_batches(of: 100) do |va_batch|
       accounts = va_batch.pluck(:account)
       result = get_inflation_rewards(accounts)
 


### PR DESCRIPTION
#### What's this PR do?
- use only active validators for commission tracking

#### How should this be manually tested?
- Verify the following scenarios on staging:
- [x] Scenario 1: these changes (https://stage.validators.app/commission-changes/179?network=mainnet) should not be recorded, because validator new identity already has 100% commission (https://stage.validators.app/validators/8WtgaPHyYEKYJf61QvEWbUbs4RijA1Cvp38B8sU2J8gh?network=mainnet)
- [x] Scenario 2: these changes (https://stage.validators.app/commission-changes/3921?network=mainnet) should not be recorded - new validator already has 100% commission (https://stage.validators.app/validators/ESYbasgzxq64N3TbutKYWbyZuzPsNxJRhF4wy1XAcNLY?locale=en&network=mainnet) 
- [ ] Verify the rest of created commission changes

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184339573)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
