### PR TITLE
184376335-filter-data-centers-by-inactive

### DIFF
--- a/app/controllers/asns_controller.rb
+++ b/app/controllers/asns_controller.rb
@@ -19,7 +19,13 @@ class AsnsController < ApplicationController
 
     @validators = Validator.joins(:validator_score_v1, :data_center)
                            .preload(:validator_score_v1, :data_center_host)
-                           .where("data_centers.id IN (?) AND validator_score_v1s.network = ? AND validator_score_v1s.active_stake > ?", data_center_ids, asn_params[:network], 0)
+                           .where(
+                             "data_centers.id IN (?)
+                             AND validators.is_active = true
+                             AND validator_score_v1s.network = ? 
+                             AND validator_score_v1s.active_stake > ?",
+                             data_center_ids, asn_params[:network], 0
+                           )
                            .filtered_by(@filter_by)
                            .order("validator_score_v1s.active_stake desc")
     

--- a/app/controllers/data_centers_controller.rb
+++ b/app/controllers/data_centers_controller.rb
@@ -25,7 +25,13 @@ class DataCentersController < ApplicationController
 
     data_centers = DataCenter.where(data_center_key: key)
     @validators = Validator.joins(:validator_score_v1, :data_center)
-                           .where("data_centers.id IN (?) AND validator_score_v1s.network = ? AND validator_score_v1s.active_stake > ?", data_centers.ids, show_params[:network], 0)
+                           .where(
+                             "data_centers.id IN (?)
+                             AND validators.is_active = true
+                             AND validator_score_v1s.network = ? 
+                             AND validator_score_v1s.active_stake > ?",
+                             data_centers.ids, show_params[:network], 0
+                           )
                            .includes(:validator_score_v1, :data_center_host)
                            .filtered_by(@filter_by)
                            .order("validator_score_v1s.active_stake desc")

--- a/app/services/sorted_data_centers.rb
+++ b/app/services/sorted_data_centers.rb
@@ -30,8 +30,13 @@ class SortedDataCenters
     select_statement << private_validators_count if @network == "mainnet"
 
     @dc_sql = DataCenter.select(select_statement)
-                        .joins(:validator_score_v1s)
-                        .where("validator_score_v1s.network = ? AND validator_score_v1s.active_stake > ?", @network, 0)
+                        .joins(validator_score_v1s: :validator)
+                        .where(
+                          "validator_score_v1s.network = ? \
+                          AND validator_score_v1s.active_stake > ? \
+                          AND validators.is_active = true",
+                          @network, 0
+                        )
                         .group(group)
 
     @total_stake = @dc_sql.inject(0) { |sum, dc| sum + dc.total_active_stake }

--- a/test/services/sorted_data_centers_test.rb
+++ b/test/services/sorted_data_centers_test.rb
@@ -80,9 +80,33 @@ class SortedDataCenterTest < ActiveSupport::TestCase
       scores_berlin << score
     end
 
+    2.times do
+      ip_address = Faker::Internet.ip_v4_address
+      validator = create(:validator, is_active: false)
+      data_center_host = create(:data_center_host, data_center: data_center_berlin)
+
+      validator_ip = create(
+        :validator_ip,
+        :active,
+        address: ip_address, 
+        validator: validator,
+        data_center_host: data_center_host
+      )
+
+      score = create(
+        :validator_score_v1,
+        ip_address: ip_address,
+        active_stake: 100,
+        network: "testnet",
+        validator: validator
+      )
+
+      scores_berlin << score
+    end
+
     scores_china.first.update(delinquent: true)
+    scores_china.last.update(delinquent: true)
     scores_berlin.first.update(delinquent: true)
-    scores_berlin.last.update(delinquent: true)
   end
 
   test "when sort_by_asn returns correct result" do
@@ -95,8 +119,8 @@ class SortedDataCenterTest < ActiveSupport::TestCase
     assert_equal 800, result[:total_stake]
     assert_equal 2, result[:results][0][1][:data_centers].count
     assert_equal 3, result[:total_delinquent]
-    assert_equal 2, result[:results][0][1][:delinquent_validators] # for traits_autonomous_system_number: 12345
-    assert_equal 1, result[:results][1][1][:delinquent_validators] # for traits_autonomous_system_number: 54321
+    assert_equal 1, result[:results][0][1][:delinquent_validators] # for traits_autonomous_system_number: 12345
+    assert_equal 2, result[:results][1][1][:delinquent_validators] # for traits_autonomous_system_number: 54321
 
   end
 
@@ -110,8 +134,7 @@ class SortedDataCenterTest < ActiveSupport::TestCase
     assert_equal 800, result[:total_stake]
     assert_equal 3, result[:results].count
     assert_equal 3, result[:total_delinquent]
-    assert_equal 1, result[:results][0][1][:delinquent_validators] # 12345-CN-Asia/Shanghai
-    assert_equal 1, result[:results][1][1][:delinquent_validators] # 54321-DE-Europe/CET
+    assert_equal 2, result[:results][0][1][:delinquent_validators] # 12345-CN-Asia/Shanghai
     assert_equal 1, result[:results][2][1][:delinquent_validators] # 12345-DE-Europe/CET
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- exclude inactive validators from data_center query

#### How should this be manually tested?
- run tests
- check index page of ASN/Data Centers - only active validators should be in the numbers

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184376335)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
