### PR TITLE
184531484 - change link from solana beach to explorer solana

### DIFF
--- a/app/javascript/packs/ping_things/ping_thing_table.vue
+++ b/app/javascript/packs/ping_things/ping_thing_table.vue
@@ -131,7 +131,7 @@
         }
       },
       link_from_signature(signature){
-        return "https://solanabeach.io/transaction/" + signature
+        return "https://explorer.solana.com/tx/" + signature
       },
       transaction_type_icon(tx){
         switch(tx){


### PR DESCRIPTION
#### What's this PR do?
PR applies minor change regarding url pointing out to solana explorer.

#### How should this be manually tested?
- locally you can create recent ping things via `ruby dev/create_test_ping_things.rb`
- verify if the links within Ping Thing site points out to the explorer solana.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184531484)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
