### PR TITLE
184297117-stake-weight-scores

### DIFF
--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -152,8 +152,11 @@ module StakeLogic
         uptimes = []
         lifetimes = []
         scores = []
+        total_active_stake = 0
 
-        Validator.where(id: validator_ids).each do |validator|
+        Validator.where(id: validator_ids).includes(:stake_accounts).each do |validator|
+          stake_acc = validator.stake_accounts.active.where(stake_pool: pool).first
+          total_active_stake += stake_acc.active_stake
           score = validator.score
 
           last_delinquent = validator.validator_histories
@@ -166,14 +169,14 @@ module StakeLogic
           lifetime = (DateTime.now - validator.created_at.to_datetime).to_i
           uptimes.push uptime
           lifetimes.push lifetime
-          scores.push score.total_score.to_i
+          scores.push stake_acc.active_stake * score.total_score.to_i
           delinquent_count = score.delinquent ? delinquent_count + 1 : delinquent_count
           last_skipped_slots.push score.skipped_slot_history&.last
         end
 
         pool.average_uptime = uptimes.average
         pool.average_lifetime = lifetimes.average
-        pool.average_score = scores.average.round(2)
+        pool.average_score = (scores.sum / total_active_stake.to_f).round(2)
         pool.average_delinquent = (delinquent_count / validator_ids.size) * 100
         pool.average_skipped_slots = last_skipped_slots.compact.average
       end

--- a/app/logic/stake_logic.rb
+++ b/app/logic/stake_logic.rb
@@ -155,8 +155,8 @@ module StakeLogic
         total_active_stake = 0
 
         Validator.where(id: validator_ids).includes(:stake_accounts).each do |validator|
-          stake_acc = validator.stake_accounts.active.where(stake_pool: pool).first
-          total_active_stake += stake_acc.active_stake
+          val_active_stake = validator.stake_accounts.active.where(stake_pool: pool).pluck(:active_stake).sum
+          total_active_stake += val_active_stake
           score = validator.score
 
           last_delinquent = validator.validator_histories
@@ -169,7 +169,7 @@ module StakeLogic
           lifetime = (DateTime.now - validator.created_at.to_datetime).to_i
           uptimes.push uptime
           lifetimes.push lifetime
-          scores.push stake_acc.active_stake * score.total_score.to_i
+          scores.push val_active_stake * score.total_score.to_i
           delinquent_count = score.delinquent ? delinquent_count + 1 : delinquent_count
           last_skipped_slots.push score.skipped_slot_history&.last
         end

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -47,6 +47,7 @@ class Validator < ApplicationRecord
   DEFAULT_FILTERS = %w(inactive active private delinquent).freeze
 
   has_many :vote_accounts, dependent: :destroy
+  has_many :stake_accounts, dependent: :destroy
   has_many :vote_account_histories, through: :vote_accounts, dependent: :destroy
   has_many :validator_ips, dependent: :nullify
   has_many :validator_block_histories, dependent: :destroy

--- a/test/logic/stake_logic_test.rb
+++ b/test/logic/stake_logic_test.rb
@@ -228,7 +228,7 @@ class StakeLogicTest < ActiveSupport::TestCase
     create(:stake_account, validator: validator3, stake_pool: stake_pool)
     Pipeline.new(200, payload).then(&update_validator_stats)
 
-    assert_equal 4.22, stake_pool.reload.average_score
+    assert_equal 4.12, stake_pool.reload.average_score
   end
 
   test "get_rewards \

--- a/test/logic/stake_logic_test.rb
+++ b/test/logic/stake_logic_test.rb
@@ -200,21 +200,21 @@ class StakeLogicTest < ActiveSupport::TestCase
     score = create(:validator_score_v1, validator: validator)
     score2 = create(:validator_score_v1, validator: validator2)
     score.update_columns(total_score: 10)
-    score2.update_columns(total_score: 9)
-    create(:stake_account, validator: validator, stake_pool: stake_pool)
-    create(:stake_account, validator: validator2, stake_pool: stake_pool)
+    score2.update_columns(total_score: 1)
+    create(:stake_account, validator: validator, stake_pool: stake_pool, active_stake: 2)
+    create(:stake_account, validator: validator2, stake_pool: stake_pool, active_stake: 6)
 
     refute stake_pool.average_score
 
     payload = @initial_payload.merge(stake_pools: [stake_pool])
     Pipeline.new(200, payload).then(&update_validator_stats)
 
-    assert_equal 9.5, stake_pool.reload.average_score
+    assert_equal 3.25, stake_pool.reload.average_score
 
     score2.update_columns(total_score: 6)
     Pipeline.new(200, payload).then(&update_validator_stats)
 
-    assert_equal 8, stake_pool.reload.average_score
+    assert_equal 7.0, stake_pool.reload.average_score
 
     validator3 = create(:validator)
     score3 = create(:validator_score_v1, validator: validator3)
@@ -222,13 +222,13 @@ class StakeLogicTest < ActiveSupport::TestCase
     create(:stake_account, validator: validator3, stake_pool: stake_pool)
     Pipeline.new(200, payload).then(&update_validator_stats)
 
-    assert_equal 5.33, stake_pool.reload.average_score
+    assert_equal 0.52, stake_pool.reload.average_score
 
     score3.update_columns(total_score: 4)
     create(:stake_account, validator: validator3, stake_pool: stake_pool)
     Pipeline.new(200, payload).then(&update_validator_stats)
 
-    assert_equal 6.67, stake_pool.reload.average_score
+    assert_equal 4.22, stake_pool.reload.average_score
   end
 
   test "get_rewards \


### PR DESCRIPTION
#### What's this PR do?
- average score for stake pools are stake-weighted

#### How should this be manually tested?
- run tests
- if you can, try to run `rails r script/gather_stake_accounts.rb` and see if the average scores are different than before

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184297117)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
