### PR TITLE
184655857 - Enable wildcard search for validator name

### DIFF
--- a/app/queries/validator_search_query.rb
+++ b/app/queries/validator_search_query.rb
@@ -14,14 +14,15 @@ class ValidatorSearchQuery
   end
 
   def search(query)
-    vacs = VoteAccount.where('account LIKE ?', "#{query}%").pluck(:validator_id)
+    vacs = VoteAccount.where("account LIKE ?", "#{query}%").pluck(:validator_id)
     @relation.where(
-      'validators.name like :q or
-      validators.account like :q or
-      validator_score_v1s.software_version like :q or
-      data_centers.data_center_key like :q or
-      validators.id IN(:vacs)',
-      q: "#{query}%",
+      "validators.name like :name_query or
+      validators.account like :query or
+      validator_score_v1s.software_version like :query or
+      data_centers.data_center_key like :query or
+      validators.id IN(:vacs)",
+      name_query: "%#{query}%",
+      query: "#{query}%",
       vacs: vacs
     )
   end

--- a/test/queries/validator_search_query_test.rb
+++ b/test/queries/validator_search_query_test.rb
@@ -59,6 +59,13 @@ class ValidatorSearchQueryTest < ActiveSupport::TestCase
     assert_equal results.to_a, @validators_name1
   end
 
+  test "returns validators for query that is any part of validator name (ame1)" do
+    query   = "ame1"
+    results = ValidatorSearchQuery.new.search(query)
+
+    assert_equal results.pluck(:name).uniq, ["Name1"]
+  end
+
   test "returns validators only for network provided in the relation" do
     query    = "Name1"
     relation = Validator.where(network: "searchnet")
@@ -70,7 +77,7 @@ class ValidatorSearchQueryTest < ActiveSupport::TestCase
   test "returns validators with name/account/software_version/data_center_key or account like query (Name)" do
     query     = "Name"
     results   = ValidatorSearchQuery.new.search(query)
-    
+
     assert_equal 9, results.count
   end
 


### PR DESCRIPTION
#### What's this PR do?
- Enables widlcard search for validator name, leaves other search fields as-is

#### How should this be manually tested?
- Go to validator search and type any part of validator name - this should return results as on attached screenshot
- Try do the same with other fields - eg. copy validator identity and truncate few characters from the beginning - this should not work. As in story description, we want to support widcard search only for validator name

<img width="1421" alt="Zrzut ekranu 2023-03-10 o 11 20 59" src="https://user-images.githubusercontent.com/32059143/224291713-4c4586b7-6bf6-41a7-8e34-6fccbb17b3a4.png">

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184655857)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
