### PR TITLE
184810886-fix-coingecko-broadcast

### DIFF
--- a/app/api_clients/coin_gecko_client.rb
+++ b/app/api_clients/coin_gecko_client.rb
@@ -8,6 +8,8 @@ require "net/http"
 class CoinGeckoClient
   attr_reader :coin
 
+  class CoinGeckoResponseError < StandardError; end
+
   def initialize(
     api_client: CoingeckoRuby::Client.new,
     coin: "solana",
@@ -27,7 +29,11 @@ class CoinGeckoClient
 
   # Fetches the current price for a coin in the given coin or currency.
   def price(ids = @coin)
-    @api_client.price(ids, include_24hr_vol: true, include_24hr_change: true)
+    begin
+      @api_client.price(ids, include_24hr_vol: true, include_24hr_change: true)
+    rescue JSON::ParserError => e
+      raise CoinGeckoResponseError
+    end
   end
 
   # ohlc - open, high, low, close


### PR DESCRIPTION
#### What's this PR do?
- avoid blocking front stats broadcast if solana prices does not load

#### How should this be manually tested?
- run `rails r daemons/front_stats_update_daemon.rb`
- check if sol prices update every minute
- check if rest of the stats loads fast

#### What are the relevant tickets?
- URL to the PivotalTracker ticket

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
