### PR TITLE
184799770 update rack attack syntax

### DIFF
--- a/app/views/public/api_documentation.html.erb
+++ b/app/views/public/api_documentation.html.erb
@@ -625,7 +625,8 @@
 <p>
   After exceeding the limit, your will get <strong>429 Too Many Requests</strong> error.
 </p>
-Limits are automatically reset after <%= @reset_period %> minutes.
+Limits are automatically reset after <%= @reset_period %> minutes. See RateLimit-Reset header to check how much time is
+left (in seconds) until the limit resets.
 
 <hr />
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,7 +9,7 @@ class Rack::Attack
 
   API_LOW_LIMIT = 25
   API_HIGH_LIMIT = 40
-  LIMIT_RESET_PERIOD = 5.minutes
+  LIMIT_RESET_PERIOD = 5.minute
 
   ### Throttle Spammy Clients ###
   # Throttle GET requests to API by user authorization token
@@ -36,7 +36,7 @@ class Rack::Attack
   ### Custom Throttle Response ###
   # By default, Rack::Attack returns an HTTP 429 for throttled responses.
   # If you want to customize the response, then uncomment the lines below.
-  self.throttled_responder = lambda do |env|
+  self.throttled_responder = lambda do |request|
     [ 429, {}, ["Too Many Requests. Retry later.\n"]]
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -36,7 +36,7 @@ class Rack::Attack
   ### Custom Throttle Response ###
   # By default, Rack::Attack returns an HTTP 429 for throttled responses.
   # If you want to customize the response, then uncomment the lines below.
-  self.throttled_response = lambda do |env|
+  self.throttled_responder = lambda do |env|
     [ 429, {}, ["Too Many Requests. Retry later.\n"]]
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,8 +7,8 @@ class Rack::Attack
     "/api/v1/ping-thing-stats"
   ].freeze
 
-  API_LOW_LIMIT = 25
-  API_HIGH_LIMIT = 40
+  API_LOW_LIMIT = 30
+  API_HIGH_LIMIT = 60
   LIMIT_RESET_PERIOD = 5.minute
 
   ### Throttle Spammy Clients ###

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,25 +39,25 @@ class Rack::Attack
   self.throttled_responder = lambda do |env|
     [ 429, {}, ["Too Many Requests. Retry later.\n"]]
   end
-end
 
-### Define whitelists ###
+  ### Define whitelists ###
 
-# Allow all internal requests
-Rack::Attack.safelist("allow internal requests") do |req|
-  key = Rails.application.credentials.api_authorization
-  req.env["HTTP_AUTHORIZATION"] == key
-end
+  # Allow all internal requests
+  self.safelist("allow internal requests") do |req|
+    key = Rails.application.credentials.api_authorization
+    req.env["HTTP_AUTHORIZATION"] == key
+  end
 
-# Allow no limit requests to specified endpoints or for specified users
-# Uncomment and edit the following lines to allow no limit requests
-# Rack::Attack.safelist("allow all requests to PATH") do |req|
-#   req.path.start_with?("/api/v1/PATH") && req.get?
-# end
+  # Allow no limit requests to specified endpoints or for specified users
+  # Uncomment and edit the following lines to allow no limit requests
+  # self.safelist("allow all requests to PATH") do |req|
+  #   req.path.start_with?("/api/v1/PATH") && req.get?
+  # end
 
-# Set no limits to all endpoints for listed users
-Rack::Attack.safelist("allow all requests for users") do |req|
-  user_token = req.env["HTTP_TOKEN"] || req.env["HTTP_AUTHORIZATION"]
-  whitelisted_tokens = Rails.application.credentials.dig(:rack_attack, :whitelist_all_endpoints)
-  user_token.in? whitelisted_tokens
+  # Set no limits to all endpoints for listed users
+  self.safelist("allow all requests for users") do |req|
+    user_token = req.env["HTTP_TOKEN"] || req.env["HTTP_AUTHORIZATION"]
+    whitelisted_tokens = Rails.application.credentials.dig(:rack_attack, :whitelist_all_endpoints)
+    user_token.in? whitelisted_tokens
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
- Updates rack::attack syntax
- Fixes 5 minutes reset period which was not working correctly (and railses limits a bit for this reason)
- Adds headers for blocked requests, so that users can see how long they should wait until the next request

#### How should this be manually tested?
- Use the software that allows you to see the returned headers
- On localhost, type `rails dev:cache` in the console. If you test on staging you can skip this step.
- Send over 30 requests to localhost:3000/api/v1/ping.json or https://stage.validators.app/api/v1/ping.json and check the headers. You should see "RateLimit-Reset" header in the response from the server that shows how many seconds remain until the limits are reset. The value should go down with each request, until it reaches 0, and then you should no longer be blocked. Please confirm that it works.

#### What are the relevant tickets?
-[ URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184799770)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
