### PR TITLE
184907142-fix-fetching-report-for-front

### DIFF
--- a/daemons/concerns/front_software_versions_module.rb
+++ b/daemons/concerns/front_software_versions_module.rb
@@ -22,11 +22,13 @@ module FrontSoftwareVersionsModule
 
   def get_latest_versions_report(network)
     @report ||= {}
-    @report[network] ||= Report.where(
+
+    current_report = Report.where(
       name: FrontStatsConstants::SOFTWARE_VERSION_REPORT_NAME,
       network: network
-    ).order(created_at: :desc).first
+    ).order(created_at: :desc)&.first
 
+    @report[network] = current_report ? current_report : @report[network]
     @report[network]&.payload
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- make sure front stats daemon is fetching the most recent software version report

#### How should this be manually tested?
- run pipeline daemons
- run front stats daemon
- run sidekiq
- run rails s
- check if software version data is changing

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184907142)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
