### PR TITLE
184941141 Remove excepions for lido

### DIFF
--- a/app/helpers/validators_helper.rb
+++ b/app/helpers/validators_helper.rb
@@ -1,15 +1,13 @@
 module ValidatorsHelper
   def displayed_validator_name(validator)
-    if validator.private_validator? && !validator.lido?
-      "Private Validator"
-    else
-      return shorten_key(validator.name) if validator.name == validator.account
-      validator.name || shorten_key(validator.account)
-    end
+    return "Private Validator" if validator.private_validator?
+    return shorten_key(validator.name) if validator.name == validator.account
+
+    validator.name || shorten_key(validator.account)
   end
 
   def displayed_validator_commission(validator)
-    unless validator.private_validator? && !validator.lido?
+    unless validator.private_validator?
       commission_tag = "<span class='d-inline-block d-lg-none'>Comm.:&nbsp;</span>"
       "<small class='text-muted text-nowrap fw-normal'>(#{commission_tag}#{validator.commission}%)</small>".html_safe
     end

--- a/app/javascript/packs/validators/validator_row.js
+++ b/app/javascript/packs/validators/validator_row.js
@@ -63,7 +63,7 @@ var ValidatorRow = Vue.component('validatorRow', {
     },
 
     displayed_validator_name() {
-      if this.is_validator_private() {
+      if(this.is_validator_private()) {
         return "Private Validator"
       } else {
         if (this.validator["name"]) {

--- a/app/javascript/packs/validators/validator_row.js
+++ b/app/javascript/packs/validators/validator_row.js
@@ -54,10 +54,6 @@ var ValidatorRow = Vue.component('validatorRow', {
       return key.substring(0, 6) + "..." + key.substring(key.length - 4)
     },
 
-    is_validator_lido() {
-      return this.validator['name']?.substring(0, 4) === 'Lido'
-    },
-
     is_validator_private() {
       return this.validator['commission'] === 100 && this.validator['network'] === 'mainnet'
     },
@@ -67,8 +63,8 @@ var ValidatorRow = Vue.component('validatorRow', {
     },
 
     displayed_validator_name() {
-      if (this.is_validator_private() && !this.is_validator_lido()) {
-        return 'Private Validator'
+      if this.is_validator_private() {
+        return "Private Validator"
       } else {
         if (this.validator["name"]) {
           return this.shortened_validator_name(this.validator["name"])
@@ -175,7 +171,7 @@ var ValidatorRow = Vue.component('validatorRow', {
             </div>
             <img :src="create_avatar_link()" class='img-circle-large' v-if="!is_validator_private()"/>
           </div>
-          
+
           <div class="column-info-name">
             <a :href="validator_url()" class="column-info-link no-watchlist fw-bold">
               {{ displayed_validator_name() }}

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -300,10 +300,6 @@ class Validator < ApplicationRecord
     score&.commission == 100 && network == 'mainnet'
   end
 
-  def lido?
-    name&.start_with?('Lido')
-  end
-
   def api_url
     Rails.application.routes.url_helpers.api_v1_validator_url(
       network: self.network,

--- a/test/helpers/validators_helper_test.rb
+++ b/test/helpers/validators_helper_test.rb
@@ -73,6 +73,6 @@ class ValidatorsHelperTest < ActiveSupport::TestCase
 
   test "#displayed_validator_commission doesn't display commission for private validator" do
     validator = create(:validator, :private)
-    assert_nil displayed_validator_commission(validator), "commission is not displayed if validator is private"
+    assert_nil displayed_validator_commission(validator)
   end
 end

--- a/test/helpers/validators_helper_test.rb
+++ b/test/helpers/validators_helper_test.rb
@@ -62,10 +62,17 @@ class ValidatorsHelperTest < ActiveSupport::TestCase
   end
 
   test "#displayed_validator_name hides name if validator is private" do
-    validator = create(:validator, :private, name: "Block Logic")
-    assert_equal "Private Validator", displayed_validator_name(validator), "private validator's name should be hidden"
+    validator = create(:validator, :private)
+    assert_equal "Private Validator", displayed_validator_name(validator)
+  end
 
-    validator = create(:validator, :private, name: "Lido / Block Logic")
-    assert_equal "Lido / Block Logic", displayed_validator_name(validator), "lido's name should not be hidden"
+  test "#displayed_validator_commission displays commission tag" do
+    validator = create(:validator, :with_score)
+    assert_includes displayed_validator_commission(validator), "10%"
+  end
+
+  test "#displayed_validator_commission doesn't display commission for private validator" do
+    validator = create(:validator, :private)
+    assert_nil displayed_validator_commission(validator), "commission is not displayed if validator is private"
   end
 end

--- a/test/models/validator_test.rb
+++ b/test/models/validator_test.rb
@@ -127,17 +127,6 @@ class ValidatorTest < ActiveSupport::TestCase
     refute create(:validator_score_v1, commission: 99, validator: @validator).validator.private_validator?
   end
 
-  test "#lido? returns true if name starts with Lido" do
-    @validator.update(network: 'mainnet', name: 'Lido / Everstake')
-    assert @validator.lido?
-
-    @validator.update(name: 'IAmNotLido')
-    refute @validator.lido?
-
-    @validator.update(name: "")
-    refute @validator.lido?
-  end
-
   test "validator attributes are correctly stored in db after using utf_8_encode method" do
     special_chars_sentence = "Staking-P◎◎l FREE Validati◎n"
 


### PR DESCRIPTION
#### What's this PR do?
- Removes `lido?` and `is_validator_lido` methods and related code

#### How should this be manually tested?
- There are no private lido validators anymore (if they're staking some private validators, they should be displayed in the same way as all private validators). So just confirm that other private validators are still correctly displayed in the tables ("Private Validator" instead of name, no commission displayed, as on the screenshot below), both on homepage and stake pools page
![Zrzut ekranu z 2023-04-19 21-18-06](https://user-images.githubusercontent.com/32059143/233177993-be0c2126-fc37-49a8-bb23-f8f38f8ad373.png)

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184941141)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
