### PR TITLE
184986979 fix validator name alignment

### DIFF
--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -226,6 +226,8 @@ table, .table {
           text-align: center;
           padding-right: 28px;
           @media(max-width: $screen-lg-max) {
+            width: 25px;
+            padding-right: 0;
             text-align: left;
             position: absolute;
             top: 0;

--- a/app/views/validators/_table.html.erb
+++ b/app/views/validators/_table.html.erb
@@ -104,7 +104,7 @@
     <tr id="row-<%= i %>">
       <td class="column-info">
         <div class="column-info-row" data-turbolinks="false">
-          <div class="column-info-avatar <%= 'no-watchlist' unless (current_user && show_watchlist_btn) %>">
+          <div class="column-info-avatar">
             <%= create_avatar_link(validator) %>
             <% if current_user && show_watchlist_btn %>
               <i class="watch-button <%= validator.watchers.include?(current_user) ? 'fa-solid' : 'fa-regular' %> fa-star"
@@ -117,7 +117,7 @@
             <% end %>
           </div>
           <div class="column-info-name">
-            <%= link_to validator_url(network: params[:network], account: validator.account), class: "column-info-link fw-bold #{'no-watchlist' unless current_user}" do %>
+            <%= link_to validator_url(network: params[:network], account: validator.account), class: "column-info-link fw-bold #{'no-watchlist' unless (current_user && show_watchlist_btn)}" do %>
               <%= displayed_validator_name(validator) %> <%= displayed_validator_commission(validator) %>
             <% end %>
             <br />


### PR DESCRIPTION
#### What's this PR do?
- Fixes validator name alignment

#### How should this be manually tested?
- See the screenshot attached to PT story. The problem occurs on data center details page, and for logged in users. So log in to your account, go to some DC page, reduce window size until avatars disappear and confirm that validator name is displayed without padding on the left. Log out and confirm it's still correct.

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/184986979)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
