### PR TITLE
185080194 - add rescues from lost db connection

### DIFF
--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -17,6 +17,10 @@ module SolanaLogic
       batch = Batch.create!(network: p.payload[:network])
 
       Pipeline.new(200, p.payload.merge(batch_uuid: batch.uuid))
+    rescue ActiveRecord::ConnectionNotEstablished => e
+      Appsignal.send_error(e)
+      puts "#{e.class}\n#{e.message}"
+      exit(500)
     rescue StandardError => e
       Pipeline.new(500, p.payload, 'Error from batch_set', e)
     end
@@ -40,6 +44,10 @@ module SolanaLogic
       batch&.save
 
       Pipeline.new(200, p.payload)
+    rescue ActiveRecord::ConnectionNotEstablished => e
+      Appsignal.send_error(e)
+      puts "#{e.class}\n#{e.message}"
+      exit(500)
     rescue StandardError => e
       Pipeline.new(500, p.payload, 'Error from batch_touch', e)
     end
@@ -65,6 +73,10 @@ module SolanaLogic
                           epoch: epoch.epoch,
                           epoch_slot_index: epoch.slot_index
                         ))
+    rescue ActiveRecord::ConnectionNotEstablished => e
+      Appsignal.send_error(e)
+      puts "#{e.class}\n#{e.message}"
+      exit(500)
     rescue StandardError => e
       Pipeline.new(500, p.payload, 'Error from epoch_get', e)
     end
@@ -161,6 +173,11 @@ module SolanaLogic
       end
 
       Pipeline.new(200, p.payload)
+
+    rescue ActiveRecord::ConnectionNotEstablished => e
+      Appsignal.send_error(e)
+      puts "#{e.class}\n#{e.message}"
+      exit(500)
     rescue StandardError => e
       Pipeline.new(500, p.payload, "Error from validator_history_update", e)
     end
@@ -400,6 +417,10 @@ module SolanaLogic
       end
 
       Pipeline.new(200, p.payload)
+    rescue ActiveRecord::ConnectionNotEstablished => e
+      Appsignal.send_error(e)
+      puts "#{e.class}\n#{e.message}"
+      exit(500)
     rescue StandardError => e
       Pipeline.new(500, p.payload, 'Error from validators_save', e)
     end
@@ -578,6 +599,10 @@ module SolanaLogic
         validator.info_pub_key = result['infoPubkey'].strip
 
         validator.save!
+      rescue ActiveRecord::ConnectionNotEstablished => e
+        Appsignal.send_error(e)
+        puts "#{e.class}\n#{e.message}"
+        exit(500)
       rescue StandardError => e
         # I don't want to break the loop, but I do want to write these to the
         # Rails log so I can see failures.


### PR DESCRIPTION
#### What's this PR do?
If db connection has been lost exit from daemon.

#### How should this be manually tested?
You can manually add `raise ActiveRecord::ConnectionNotEstablished` in `solana_logic.rb` within the logic inside and check if the script has been closed.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185080194)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
