### PR TITLE
185232287 - add validator_id to validator history

### DIFF
--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -655,7 +655,7 @@ module SolanaLogic
     accounts = validator_attrs.map { |validator| validator["identityPubkey"] }
     db_validator_accounts = Validator.where(network: network, account: accounts)
                                      .map { |v| { v.account => v.id }}
-                                     .reduce({}, :merge)
+                                     .inject({}, :merge)
 
     validator_attrs.map do |validator|
       if db_validator_accounts[validator["identityPubkey"]]

--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -123,7 +123,7 @@ module SolanaLogic
 
       existing_validators(validators["validators"], p.payload[:network]).each do |validator|
         next if Rails.application.config.validator_blacklist[p.payload[:network]].include? validator["identityPubkey"]
-        
+
         if existing_history = validator_histories[validator["identityPubkey"]]
           if existing_history.last_vote < validator["lastVote"]
             existing_history.update(
@@ -142,7 +142,8 @@ module SolanaLogic
               root_distance: max_root_height - validator["rootSlot"].to_i,
               vote_distance: max_vote_height - validator["lastVote"].to_i,
               max_root_height: max_root_height,
-              max_vote_height: max_vote_height
+              max_vote_height: max_vote_height,
+              validator_id: validator["id"]
             )
 
             validator_histories[validator["identityPubkey"]] = existing_history
@@ -166,7 +167,8 @@ module SolanaLogic
             root_distance: max_root_height - validator["rootSlot"].to_i,
             vote_distance: max_vote_height - validator["lastVote"].to_i,
             max_root_height: max_root_height,
-            max_vote_height: max_vote_height
+            max_vote_height: max_vote_height,
+            validator_id: validator["id"]
           )
           validator_histories[validator["identityPubkey"]] = vh
         end
@@ -651,9 +653,15 @@ module SolanaLogic
 
   def existing_validators(validator_attrs, network)
     accounts = validator_attrs.map { |validator| validator["identityPubkey"] }
-    db_validator_accounts = Validator.where(network: network, account: accounts).pluck(:account)
-    validator_attrs.select do |validator|
-      db_validator_accounts.include?(validator["identityPubkey"])
-    end
+    db_validator_accounts = Validator.where(network: network, account: accounts)
+                                     .map { |v| { v.account => v.id }}
+                                     .reduce({}, :merge)
+
+    validator_attrs.map do |validator|
+      if db_validator_accounts[validator["identityPubkey"]]
+        validator["id"] = db_validator_accounts[validator["identityPubkey"]]
+        validator
+      end
+    end.compact
   end
 end

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -154,10 +154,7 @@ class Validator < ApplicationRecord
   end
 
   def validator_history_last
-    ValidatorHistory.where(
-      network: network,
-      account: account
-    ).last
+    validator_histories.last
   end
 
   # Return the vote account that was most recently used

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -57,7 +57,7 @@ class Validator < ApplicationRecord
   has_many :validator_ips, dependent: :nullify
   has_many :validator_block_histories, dependent: :destroy
   has_many :commission_histories, dependent: :destroy
-  has_many :validator_histories, primary_key: :account, foreign_key: :account
+  has_many :validator_histories, dependent: :nullify
 
   has_many :user_watchlist_elements, dependent: :destroy
   has_many :watchers, through: :user_watchlist_elements, source: :user

--- a/app/models/validator_history.rb
+++ b/app/models/validator_history.rb
@@ -25,7 +25,7 @@
 #  vote_distance    :bigint           unsigned
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  validator_id     :integer          not null
+#  validator_id     :integer
 #
 # Indexes
 #

--- a/app/models/validator_history.rb
+++ b/app/models/validator_history.rb
@@ -44,7 +44,7 @@ class ValidatorHistory < ApplicationRecord
     epoch
   ].freeze
 
-  belongs_to :validator
+  belongs_to :validator, optional: true
 
   scope :for_batch, ->(network, batch_uuid) { where(network: network, batch_uuid: batch_uuid) }
   scope :most_recent_epoch_credits_by_account, -> do

--- a/app/models/validator_history.rb
+++ b/app/models/validator_history.rb
@@ -25,6 +25,7 @@
 #  vote_distance    :bigint           unsigned
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  validator_id     :integer          not null
 #
 # Indexes
 #
@@ -32,6 +33,7 @@
 #  delinquent_by_account_index                                      (account,delinquent,created_at)
 #  index_validator_histories_on_network_and_account_and_id          (network,account,id)
 #  index_validator_histories_on_network_and_batch_uuid_and_account  (network,batch_uuid,account)
+#  index_validator_histories_on_validator_id                        (validator_id)
 #
 class ValidatorHistory < ApplicationRecord
   # Use the monkey patch for median
@@ -41,6 +43,8 @@ class ValidatorHistory < ApplicationRecord
     epoch_credits
     epoch
   ].freeze
+
+  belongs_to :validator
 
   scope :for_batch, ->(network, batch_uuid) { where(network: network, batch_uuid: batch_uuid) }
   scope :most_recent_epoch_credits_by_account, -> do
@@ -95,10 +99,6 @@ class ValidatorHistory < ApplicationRecord
     def median_last_vote_for(network, batch_uuid)
       for_batch(network, batch_uuid).median(:last_vote)
     end
-  end
-
-  def validator
-    Validator.find_by(network: network, account: account)
   end
 
   def to_builder

--- a/db/migrate/20230602122559_add_validator_id_to_validator_histories.rb
+++ b/db/migrate/20230602122559_add_validator_id_to_validator_histories.rb
@@ -2,7 +2,7 @@
 
 class AddValidatorIdToValidatorHistories < ActiveRecord::Migration[6.1]
   def change
-    add_column :validator_histories, :validator_id, :integer, null: false, foreign_key: true
+    add_column :validator_histories, :validator_id, :integer, null: true, foreign_key: true
     add_index :validator_histories, :validator_id
   end
 end

--- a/db/migrate/20230602122559_add_validator_id_to_validator_histories.rb
+++ b/db/migrate/20230602122559_add_validator_id_to_validator_histories.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddValidatorIdToValidatorHistories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :validator_histories, :validator_id, :integer, null: false, foreign_key: true
+    add_index :validator_histories, :validator_id
+  end
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_19_115610) do
+ActiveRecord::Schema.define(version: 2023_06_02_122559) do
+
   create_table "account_authority_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "authorized_withdrawer_before"
     t.string "authorized_withdrawer_after"
@@ -554,10 +555,12 @@ ActiveRecord::Schema.define(version: 2023_04_19_115610) do
     t.bigint "max_vote_height", unsigned: true
     t.bigint "vote_distance", unsigned: true
     t.integer "epoch"
+    t.integer "validator_id", null: false
     t.index ["account", "created_at", "active_stake"], name: "acceptable_stake_by_account_index"
     t.index ["account", "delinquent", "created_at"], name: "delinquent_by_account_index"
     t.index ["network", "account", "id"], name: "index_validator_histories_on_network_and_account_and_id"
     t.index ["network", "batch_uuid", "account"], name: "index_validator_histories_on_network_and_batch_uuid_and_account"
+    t.index ["validator_id"], name: "index_validator_histories_on_validator_id"
   end
 
   create_table "validator_ips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -555,7 +555,7 @@ ActiveRecord::Schema.define(version: 2023_06_02_122559) do
     t.bigint "max_vote_height", unsigned: true
     t.bigint "vote_distance", unsigned: true
     t.integer "epoch"
-    t.integer "validator_id", null: false
+    t.integer "validator_id"
     t.index ["account", "created_at", "active_stake"], name: "acceptable_stake_by_account_index"
     t.index ["account", "delinquent", "created_at"], name: "delinquent_by_account_index"
     t.index ["network", "account", "id"], name: "index_validator_histories_on_network_and_account_and_id"

--- a/script/one_time_scripts/add_validator_id_to_validator_histories.rb
+++ b/script/one_time_scripts/add_validator_id_to_validator_histories.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../config/environment', __dir__)
+
+ValidatorHistory.find_each do |vh|
+  next if vh.validator
+
+  validator = Validator.find_by(network: vh.network, account: vh.account)
+  next unless validator
+
+  ValidatorHistory.where(network: vh.network, account: vh.account)
+                  .update_all(validator_id: validator.id)
+end

--- a/test/controllers/api/v1/validators_controller_test.rb
+++ b/test/controllers/api/v1/validators_controller_test.rb
@@ -63,7 +63,11 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
       :with_data_center_through_validator_ip, 
       account: "Test Account"
     )
-    create(:validator_history, account: validator.account, epoch_credits: 100, epoch: 222)
+    create(:validator_history,
+           account: validator.account,
+           epoch_credits: 100,
+           epoch: 222,
+           validator: validator)
     create(:vote_account, validator: validator)
     create(:report, :build_skipped_slot_percent)
 
@@ -332,7 +336,11 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
       :with_data_center_through_validator_ip, 
       account: "Test Account"
     )
-    create(:validator_history, account: validator.account, epoch_credits: 100, epoch: 222)
+    create(:validator_history,
+           account: validator.account,
+           epoch_credits: 100,
+           epoch: 222,
+           validator: validator)
     create(:vote_account, validator: validator)
     create(:report, :build_skipped_slot_percent)
 
@@ -400,7 +408,11 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
       :with_data_center_through_validator_ip, 
       account: "Test Account"
     )
-    create(:validator_history, account: validator.account, epoch_credits: 100, epoch: 222)
+    create(:validator_history,
+           account: validator.account,
+           epoch_credits: 100,
+           epoch: 222,
+           validator: validator)
     create(:vote_account, validator: validator)
     create(:report, :build_skipped_slot_percent)
 
@@ -467,7 +479,11 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
       :with_data_center_through_validator_ip,
       account: "Test Account"
     )
-    create(:validator_history, account: validator.account, epoch_credits: 100, epoch: 222)
+    create(:validator_history,
+           account: validator.account,
+           epoch_credits: 100,
+           epoch: 222,
+           validator: validator)
     create(:vote_account, validator: validator)
     create(:report, :build_skipped_slot_percent)
 
@@ -502,7 +518,11 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
       :with_data_center_through_validator_ip,
       account: "Test Account"
     )
-    create(:validator_history, account: validator.account, epoch_credits: 100, epoch: 222)
+    create(:validator_history,
+           account: validator.account,
+           epoch_credits: 100,
+           epoch: 222,
+           validator: validator)
     create(:vote_account, validator: validator)
     create(:report, :build_skipped_slot_percent)
     

--- a/test/factories/validator_histories.rb
+++ b/test/factories/validator_histories.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     credits { 1 }
     active_stake { 100 }
     delinquent { false }
+    validator
   end
 end

--- a/test/fixtures/validator_histories.yml
+++ b/test/fixtures/validator_histories.yml
@@ -9,3 +9,4 @@ one:
   credits: 1
   active_stake: 100
   delinquent: false
+  validator_id: 1

--- a/test/logic/solana_logic_test.rb
+++ b/test/logic/solana_logic_test.rb
@@ -176,7 +176,7 @@ class SolanaLogicTest < ActiveSupport::TestCase
       ]
     }.to_json
 
-    create(:validator, account: "4wjZmBoiwQ2s3fEL1og4gUcgWNtJoEkXNdG1yMW44nzr")
+    v = create(:validator, account: "4wjZmBoiwQ2s3fEL1og4gUcgWNtJoEkXNdG1yMW44nzr")
 
     SolanaCliService.stub(:request, json_data, ["validators", @testnet_url]) do
       VCR.use_cassette("validator_history_update") do
@@ -188,6 +188,7 @@ class SolanaLogicTest < ActiveSupport::TestCase
 
         assert_equal 200, p.code
         assert validator_histories.size == 1
+        assert validator_histories.first.validator, v
       end
     end
   end

--- a/test/logic/stake_logic_test.rb
+++ b/test/logic/stake_logic_test.rb
@@ -332,8 +332,8 @@ class StakeLogicTest < ActiveSupport::TestCase
 
   test "calculate_apy_for_pools should return correct average apy for lido" do
     stake_pool = create(:stake_pool, network: "testnet", name: "Lido")
-    create(:validator_history, account: "lido_account", active_stake: 100)
     val = create(:validator, account: "lido_account")
+    create(:validator_history, account: "lido_account", active_stake: 100, validator: val)
 
     create(
       :stake_account_history,

--- a/test/logic/validator_score_v1_logic_test.rb
+++ b/test/logic/validator_score_v1_logic_test.rb
@@ -46,7 +46,8 @@ class ValidatorScoreV1LogicTest < ActiveSupport::TestCase
         :validator_history,
         network: 'testnet',
         batch_uuid: '1234',
-        account: v.account
+        account: v.account,
+        validator: v
       )
       create(
         :vote_account_history,
@@ -107,7 +108,8 @@ class ValidatorScoreV1LogicTest < ActiveSupport::TestCase
         :validator_history,
         network: 'testnet',
         batch_uuid: '1234',
-        account: v.account
+        account: v.account,
+        validator: v
       )
       create(
         :vote_account_history,

--- a/test/models/stats/validator_score_test.rb
+++ b/test/models/stats/validator_score_test.rb
@@ -24,7 +24,8 @@ module Stats
                                    account: validator.account,
                                    root_block: 2,
                                    last_vote: 21,
-                                   active_stake: 10)
+                                   active_stake: 10,
+                                   validator: validator)
       end
       @validator_scores = @validators.map(&:score)
       @validator_scores.last.update(active_stake: nil)

--- a/test/models/validator_history_test.rb
+++ b/test/models/validator_history_test.rb
@@ -37,7 +37,9 @@ class ValidatorHistoryTest < ActiveSupport::TestCase
 
   test 'relationships belongs_to validator' do
     validator = create(:validator)
-    validator_history = create(:validator_history, account: validator.account)
+    validator_history = create(:validator_history,
+                               account: validator.account,
+                               validator: validator)
 
     assert_equal validator, validator_history.validator
   end
@@ -52,7 +54,8 @@ class ValidatorHistoryTest < ActiveSupport::TestCase
         account: @validator.account,
         created_at: arr[0], 
         epoch_credits: arr[1],
-        epoch: 222
+        epoch: 222,
+        validator: @validator
       )
     end
 
@@ -74,7 +77,8 @@ class ValidatorHistoryTest < ActiveSupport::TestCase
         :validator_history,
         network: @network,
         account: @account,
-        created_at: n.minutes.ago
+        created_at: n.minutes.ago,
+        validator: @validator
       )
     end
 
@@ -93,21 +97,24 @@ class ValidatorHistoryTest < ActiveSupport::TestCase
       :validator_history,
       network: @network,
       account: @account,
-      created_at: 20.hours.ago
+      created_at: 20.hours.ago,
+      validator: @validator
     )
 
     create(
       :validator_history,
       network: @network,
       account: @account,
-      created_at: 25.hours.ago
+      created_at: 25.hours.ago,
+      validator: @validator
     )
 
     create(
       :validator_history,
       network: "mainnet",
       account: @account,
-      created_at: 2.hours.ago
+      created_at: 2.hours.ago,
+      validator: @validator
     )
 
     result = ValidatorHistory.validator_histories_from_period(

--- a/test/models/validator_test.rb
+++ b/test/models/validator_test.rb
@@ -36,7 +36,11 @@ class ValidatorTest < ActiveSupport::TestCase
   end
 
   test "relationship has_one most_recent_epoch_credits_by_account" do
-    create_list(:validator_history, 5, account: @validator.account, epoch_credits: 100)
+    create_list(:validator_history,
+                5,
+                account: @validator.account,
+                epoch_credits: 100,
+                validator: @validator)
 
     assert_equal 100, @validator.most_recent_epoch_credits_by_account.epoch_credits
   end

--- a/test/queries/validator_score_query_test.rb
+++ b/test/queries/validator_score_query_test.rb
@@ -21,7 +21,8 @@ class ValidatorScoreQueryTest < ActiveSupport::TestCase
         root_block: 2,
         last_vote: 21,
         active_stake: 10,
-        network: "testnet"
+        network: "testnet",
+        validator: validator
       )
     end
 

--- a/test/scripts/add_validator_id_to_validator_histories_test.rb
+++ b/test/scripts/add_validator_id_to_validator_histories_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AddValidatorIdToValidatorHistoriesTest < ActiveSupport::TestCase
+  test "script ignores validator histories that validator not exists" do
+    vh = create(:validator_history, validator_id: nil)
+
+    load(Rails.root.join("script", "one_time_scripts", "add_validator_id_to_validator_histories.rb"))
+    
+    assert_nil vh.validator_id
+  end
+
+  test "script adds an association to validator_histories that validator persists" do
+    validator = create(:validator, account: "test_account")
+    vhs = create_list(:validator_history,
+                      10,
+                      account: "test_account",
+                      validator_id: nil)
+
+    load(Rails.root.join("script", "one_time_scripts", "add_validator_id_to_validator_histories.rb"))
+
+    assert vhs.map(&:validator_id).uniq, [validator.id]
+  end
+end

--- a/test/scripts/back_fill_commission_history_script_test.rb
+++ b/test/scripts/back_fill_commission_history_script_test.rb
@@ -15,7 +15,8 @@ class AddCurrentEpochScriptTest < ActiveSupport::TestCase
         account: v.account,
         commission: this_commission,
         network: v.network,
-        created_at: DateTime.new(2021, 7, 9) - i.minutes
+        created_at: DateTime.new(2021, 7, 9) - i.minutes,
+        validator: v
       )
     end
   end

--- a/test/services/stake_pools/calculate_average_stats_test.rb
+++ b/test/services/stake_pools/calculate_average_stats_test.rb
@@ -62,14 +62,16 @@ module StakePools
         network: "testnet",
         delinquent: true,
         created_at: DateTime.now - 3.days,
-        account: "account_test"
+        account: "account_test",
+        validator: @validator
       )
       create(
         :validator_history,
         network: "testnet",
         delinquent: true,
         created_at: DateTime.now - 3.days,
-        account: "account_test_2"
+        account: "account_test_2",
+        validator: @validator_2
       )
 
       StakePools::CalculateAverageStats.new(@stake_pool).call

--- a/test/workers/validator_check_active_worker_test.rb
+++ b/test/workers/validator_check_active_worker_test.rb
@@ -8,7 +8,7 @@ class ValidatorCheckActiveWorkerTest < ActiveSupport::TestCase
 
   test 'worker should be performed as expected' do
     v = create(:validator, :with_score, account: 'account1')
-    create(:validator_history, account: 'account1')
+    create(:validator_history, account: 'account1', validator: v)
     create(:validator_block_history, validator: v, epoch: 124)
 
     Sidekiq::Testing.inline! do

--- a/test/workers/validator_check_active_worker_test.rb
+++ b/test/workers/validator_check_active_worker_test.rb
@@ -8,7 +8,7 @@ class ValidatorCheckActiveWorkerTest < ActiveSupport::TestCase
 
   test 'worker should be performed as expected' do
     v = create(:validator, :with_score, account: 'account1')
-    create(:validator_history, account: 'account1', validator: v)
+    create(:validator_history, account: "account1", validator: v)
     create(:validator_block_history, validator: v, epoch: 124)
 
     Sidekiq::Testing.inline! do


### PR DESCRIPTION
#### What's this PR do?
Add a validator association to validator histories. For minitest tests the only change is that the validator_id were injected, except one added test covering a new script.

#### How should this be manually tested?
- `rails test`
- check if none of the ValidatorHistory records locally does not have validator_id assigned
- execute and compare results for `rails r script/one_time_scripts/add_validator_id_to_validator_histories.rb`. It shouldn't rise any errors. All validator histories should now have validator_id assigned in, except those one that the validator does not exist anymore
- I had about 200k records and it took about ~1 minute to process in.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185232287)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
