### PR TITLE
185302616 - fix saving Authorized Voters change

### DIFF
--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -74,7 +74,7 @@ class VoteAccount < ApplicationRecord
     return true if changes.size == 1
 
     before_changes, after_changes = changes.first, changes.last
-    !(before_changes <=> after_changes).zero?
+    before_changes.sort != after_changes.sort
   end
 
   def create_account_authority_history

--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -66,12 +66,13 @@ class VoteAccount < ApplicationRecord
   end
 
   def authorized_voters_value_changed?
-    changes = Array(saved_changes[:authorized_voters]).compact
+    changes = Array(saved_changes[:authorized_voters]).compact.map(&:values)
 
     # create
     return true if changes.size == 1
 
-    changes.map(&:values).flatten.uniq.size > 1
+    before_changes, after_changes = changes.first, changes.last
+    before_changes.size != (before_changes & after_changes).size
   end
 
   def create_account_authority_history

--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+app/models/vote_account.rb# frozen_string_literal: true
 
 # == Schema Information
 #
@@ -66,6 +66,8 @@ class VoteAccount < ApplicationRecord
   end
 
   def authorized_voters_value_changed?
+    return unless saved_change_to_authorized_voters?
+
     changes = Array(saved_changes[:authorized_voters]).compact.map(&:values)
 
     # create

--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -74,7 +74,7 @@ class VoteAccount < ApplicationRecord
     return true if changes.size == 1
 
     before_changes, after_changes = changes.first, changes.last
-    before_changes.size != (before_changes & after_changes).size
+    !(before_changes <=> after_changes).zero?
   end
 
   def create_account_authority_history

--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -1,4 +1,4 @@
-app/models/vote_account.rb# frozen_string_literal: true
+# frozen_string_literal: true
 
 # == Schema Information
 #

--- a/script/one_time_scripts/remove_invalid_authorized_voters.rb
+++ b/script/one_time_scripts/remove_invalid_authorized_voters.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../config/environment', __dir__)
+
+VoteAccount.joins(:account_authority_histories)
+           .includes(:account_authority_histories)
+           .find_each do |va|
+  invalid_voters = va.account_authority_histories.select do |history|
+    if history.authorized_withdrawer_after == history.authorized_withdrawer_before
+      before_values = Array(history.authorized_voters_before&.values)
+      after_values = Array(history.authorized_voters_after&.values)
+
+      before_values.size == (before_values & after_values).size
+    end
+  end
+
+  AccountAuthorityHistory.where(id: invalid_voters).destroy_all
+
+  history_last = va.account_authority_histories.last
+
+  if va.authorized_voters != history_last.authorized_voters_after ||
+    va.authorized_withdrawer != history_last.authorized_withdrawer_after
+    va.update_columns(
+      authorized_voters: history_last.authorized_voters_after,
+      authorized_withdrawer: history_last.authorized_withdrawer_after
+    )
+  end
+end

--- a/script/one_time_scripts/remove_invalid_authorized_voters.rb
+++ b/script/one_time_scripts/remove_invalid_authorized_voters.rb
@@ -10,7 +10,7 @@ VoteAccount.joins(:account_authority_histories)
       before_values = Array(history.authorized_voters_before&.values)
       after_values = Array(history.authorized_voters_after&.values)
 
-      (before_values <=> after_values).zero?
+      before_values.sort == after_values.sort
     end
   end
 

--- a/script/one_time_scripts/remove_invalid_authorized_voters.rb
+++ b/script/one_time_scripts/remove_invalid_authorized_voters.rb
@@ -10,7 +10,7 @@ VoteAccount.joins(:account_authority_histories)
       before_values = Array(history.authorized_voters_before&.values)
       after_values = Array(history.authorized_voters_after&.values)
 
-      before_values.size == (before_values & after_values).size
+      (before_values <=> after_values).zero?
     end
   end
 

--- a/script/one_time_scripts/remove_invalid_authorized_voters.rb
+++ b/script/one_time_scripts/remove_invalid_authorized_voters.rb
@@ -18,11 +18,7 @@ VoteAccount.joins(:account_authority_histories)
 
   history_last = va.account_authority_histories.last
 
-  if va.authorized_voters != history_last.authorized_voters_after ||
-    va.authorized_withdrawer != history_last.authorized_withdrawer_after
-    va.update_columns(
-      authorized_voters: history_last.authorized_voters_after,
-      authorized_withdrawer: history_last.authorized_withdrawer_after
-    )
+  if va.authorized_voters != history_last.authorized_voters_after
+    va.update_column(:authorized_voters, history_last.authorized_voters_after)
   end
 end

--- a/test/models/vote_account_test.rb
+++ b/test/models/vote_account_test.rb
@@ -16,7 +16,7 @@ class VoteAccountTest < ActiveSupport::TestCase
   end
 
   class AuthorizedVotersTests < ActiveSupport::TestCase
-    test "returns valid history attributes during the update with a single key" do
+    test "returns valid history attributes when authorization has changed" do
       vote_account = create(:vote_account, authorized_voters: { "test_voter_key" => "test_voter_value" })
       vote_account.update(authorized_voters: { "test_voter_key_2" => "test_voter_value_2" })
 
@@ -26,15 +26,15 @@ class VoteAccountTest < ActiveSupport::TestCase
       assert_equal va_history.authorized_voters_after, { "test_voter_key_2" => "test_voter_value_2" }
     end
 
-    test "returns valid history attributes during the update with multiple keys" do
+    test "returns valid history attributes when new authorization has been added" do
       vote_account = create(
         :vote_account,
         authorized_voters: { "test_voter_key" => "test_voter_value" }
       )
       vote_account.update(
         authorized_voters: {
-          "test_voter_key_2" => "test_voter_value_2",
-          "test_voter_key_3" => "test_voter_value_3"
+          "test_voter_key" => "test_voter_value",
+          "test_voter_key_2" => "test_voter_value_2"
         }
       )
 
@@ -43,12 +43,12 @@ class VoteAccountTest < ActiveSupport::TestCase
         "test_voter_key" => "test_voter_value"
       }
       assert_equal va_history.authorized_voters_after, {
-        "test_voter_key_2" => "test_voter_value_2",
-        "test_voter_key_3" => "test_voter_value_3"
+        "test_voter_key" => "test_voter_value",
+        "test_voter_key_2" => "test_voter_value_2"
       }
     end
 
-    test "returns valid history attributes during the update with multiple keys but different keys only" do
+    test "returns valid history attributes when authorizations have keys changed only" do
       vote_account = create(
         :vote_account,
         authorized_voters: {
@@ -58,8 +58,8 @@ class VoteAccountTest < ActiveSupport::TestCase
       )
       vote_account.update(
         authorized_voters: {
-          "test_voter_key_3" => "test_voter_value",
-          "test_voter_key_4" => "test_voter_value_2"
+          "test_voter_key_2" => "test_voter_value",
+          "test_voter_key_3" => "test_voter_value_2"
         }
       )
 
@@ -71,14 +71,14 @@ class VoteAccountTest < ActiveSupport::TestCase
       }
     end
 
-    test "skips saving history if authorized_voters does not change" do
+    test "skips saving history if authorizations do not change" do
       vote_account = create(:vote_account, authorized_voters: nil)
       vote_account.update(authorized_voters: nil)
 
       assert_empty vote_account.account_authority_histories
     end
 
-    test "returns valid history attributes during the update with nil" do
+    test "returns valid history attributes when authorizations have changed to nil" do
       vote_account = create(
         :vote_account,
         authorized_voters: {
@@ -94,6 +94,30 @@ class VoteAccountTest < ActiveSupport::TestCase
         "test_voter_key_2" => "test_voter_value_2"
       }
       assert_nil va_history.authorized_voters_after
+    end
+
+    test "returns valid history attributes when an authorization has been removed" do
+      vote_account = create(
+        :vote_account,
+        authorized_voters: {
+          "test_voter_key" => "test_voter_value",
+          "test_voter_key_2" => "test_voter_value_2"
+        }
+      )
+      vote_account.update(
+        authorized_voters: {
+          "test_voter_key_2" => "test_voter_value_2"
+        }
+      )
+
+      va_history = vote_account.account_authority_histories.last
+      assert_equal va_history.authorized_voters_before, {
+        "test_voter_key" => "test_voter_value",
+        "test_voter_key_2" => "test_voter_value_2"
+      }
+      assert_equal va_history.authorized_voters_after, {
+        "test_voter_key_2" => "test_voter_value_2"
+      }
     end
   end
 end

--- a/test/models/vote_account_test.rb
+++ b/test/models/vote_account_test.rb
@@ -119,5 +119,29 @@ class VoteAccountTest < ActiveSupport::TestCase
         "test_voter_key_2" => "test_voter_value_2"
       }
     end
+
+    test "returns valid history attributes when authorizations have been mixed up" do
+      vote_account = create(
+        :vote_account,
+        authorized_voters: {
+          "test_voter_key" => "test_voter_value",
+          "test_voter_key_2" => "test_voter_value_2"
+        }
+      )
+      vote_account.update(
+        authorized_voters: {
+          "test_voter_key_2" => "test_voter_value_2",
+          "test_voter_key" => "test_voter_value"
+        }
+      )
+
+      va_history = vote_account.account_authority_histories.last
+
+      assert_nil va_history.authorized_voters_before
+      assert_equal va_history.authorized_voters_after, {
+        "test_voter_key" => "test_voter_value",
+        "test_voter_key_2" => "test_voter_value_2"
+      }
+    end
   end
 end

--- a/test/models/vote_account_test.rb
+++ b/test/models/vote_account_test.rb
@@ -56,7 +56,6 @@ class VoteAccountTest < ActiveSupport::TestCase
           "test_voter_key_2" => "test_voter_value_2"
         }
       )
-
       vote_account.update(
         authorized_voters: {
           "test_voter_key_3" => "test_voter_value",
@@ -77,6 +76,24 @@ class VoteAccountTest < ActiveSupport::TestCase
       vote_account.update(authorized_voters: nil)
 
       assert_empty vote_account.account_authority_histories
+    end
+
+    test "returns valid history attributes during the update with nil" do
+      vote_account = create(
+        :vote_account,
+        authorized_voters: {
+          "test_voter_key" => "test_voter_value",
+          "test_voter_key_2" => "test_voter_value_2"
+        }
+      )
+      vote_account.update(authorized_voters: nil)
+
+      va_history = vote_account.account_authority_histories.last
+      assert_equal va_history.authorized_voters_before, {
+        "test_voter_key" => "test_voter_value",
+        "test_voter_key_2" => "test_voter_value_2"
+      }
+      assert_nil va_history.authorized_voters_after
     end
   end
 end

--- a/test/models/vote_account_test.rb
+++ b/test/models/vote_account_test.rb
@@ -23,9 +23,16 @@ class VoteAccountTest < ActiveSupport::TestCase
     vote_account = create(:vote_account, authorized_voters: { "test_voter_key" => "test_voter_value" })
     vote_account.update(authorized_voters: { "test_voter_key_2" => "test_voter_value_2" })
 
-    va_histories = vote_account.account_authority_histories
+    va_history = vote_account.account_authority_histories.last
 
-    assert_equal va_histories.last.authorized_voters_before, { "test_voter_key" => "test_voter_value" }
-    assert_equal va_histories.last.authorized_voters_after, { "test_voter_key_2" => "test_voter_value_2" }
+    assert_equal va_history.authorized_voters_before, { "test_voter_key" => "test_voter_value" }
+    assert_equal va_history.authorized_voters_after, { "test_voter_key_2" => "test_voter_value_2" }
+
+    vote_account.update(authorized_voters: { "test_voter_key_3" => "test_voter_value_2" })
+
+    va_history = vote_account.account_authority_histories.last
+
+    assert_equal va_history.authorized_voters_before, { "test_voter_key" => "test_voter_value" }
+    assert_equal va_history.authorized_voters_after, { "test_voter_key_2" => "test_voter_value_2" }
   end
 end

--- a/test/models/vote_account_test.rb
+++ b/test/models/vote_account_test.rb
@@ -16,7 +16,7 @@ class VoteAccountTest < ActiveSupport::TestCase
   end
 
   class AuthorizedVotersTests < ActiveSupport::TestCase
-    test "returns valid attributes during the update with a single key" do
+    test "returns valid history attributes during the update with a single key" do
       vote_account = create(:vote_account, authorized_voters: { "test_voter_key" => "test_voter_value" })
       vote_account.update(authorized_voters: { "test_voter_key_2" => "test_voter_value_2" })
 
@@ -26,7 +26,7 @@ class VoteAccountTest < ActiveSupport::TestCase
       assert_equal va_history.authorized_voters_after, { "test_voter_key_2" => "test_voter_value_2" }
     end
 
-    test "returns valid attributes during the update with multiple keys" do
+    test "returns valid history attributes during the update with multiple keys" do
       vote_account = create(
         :vote_account,
         authorized_voters: { "test_voter_key" => "test_voter_value" }
@@ -48,7 +48,7 @@ class VoteAccountTest < ActiveSupport::TestCase
       }
     end
 
-    test "returns valid attributes during the update with multiple keys but different keys only" do
+    test "returns valid history attributes during the update with multiple keys but different keys only" do
       vote_account = create(
         :vote_account,
         authorized_voters: {
@@ -70,6 +70,13 @@ class VoteAccountTest < ActiveSupport::TestCase
         "test_voter_key" => "test_voter_value",
         "test_voter_key_2" => "test_voter_value_2"
       }
+    end
+
+    test "skips saving history if authorized_voters does not change" do
+      vote_account = create(:vote_account, authorized_voters: nil)
+      vote_account.update(authorized_voters: nil)
+
+      assert_empty vote_account.account_authority_histories
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
PR applies changes to callback logic for authorized_voters. New AccountAuthorityHistory record should be created if authorized_voters hash values have changed. New one time script will remove invalid authorized voters histories.

#### How should this be manually tested?
- execute `rails r script/one_time_scripts/remove_invalid_authorized_voters.rb` and look for any errors
- vote accounts should have most recent authorized_voters value (from latest history)
- verify via console if there are repeated values of authorized_voters hash within each VoteAccount record. If so then the script has failed.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185302616)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
