### PR TITLE
185454134 hide authority changes with nil before

### DIFF
--- a/app/javascript/packs/account_authority_histories/index_template.vue
+++ b/app/javascript/packs/account_authority_histories/index_template.vue
@@ -120,6 +120,8 @@
                ctx.histories = response.data.authority_changes
                ctx.total_count = response.data.total_count
                ctx.is_loading = false
+               console.log(ctx.histories)
+               console.log(ctx.total_count)
              })
       }
     },

--- a/app/javascript/packs/account_authority_histories/index_template.vue
+++ b/app/javascript/packs/account_authority_histories/index_template.vue
@@ -120,8 +120,6 @@
                ctx.histories = response.data.authority_changes
                ctx.total_count = response.data.total_count
                ctx.is_loading = false
-               console.log(ctx.histories)
-               console.log(ctx.total_count)
              })
       }
     },

--- a/app/queries/account_authority_query.rb
+++ b/app/queries/account_authority_query.rb
@@ -12,6 +12,7 @@ class AccountAuthorityQuery
     @results = AccountAuthorityHistory.joins(:vote_account)
                                       .includes(:vote_account)
                                       .where(network: network)
+                                      .where("authorized_withdrawer_before IS NOT NULL OR authorized_voters_before IS NOT NULL")
   end
 
   def call

--- a/app/queries/account_authority_query.rb
+++ b/app/queries/account_authority_query.rb
@@ -12,7 +12,10 @@ class AccountAuthorityQuery
     @results = AccountAuthorityHistory.joins(:vote_account)
                                       .includes(:vote_account)
                                       .where(network: network)
-                                      .where("authorized_withdrawer_before IS NOT NULL OR authorized_voters_before IS NOT NULL")
+                                      .where("authorized_withdrawer_before IS NOT NULL \
+                                              OR authorized_voters_before IS NOT NULL")
+                                      .where("authorized_withdrawer_before <> authorized_withdrawer_after \
+                                              OR authorized_voters_before <> authorized_voters_after")
   end
 
   def call

--- a/test/queries/account_authority_query_test.rb
+++ b/test/queries/account_authority_query_test.rb
@@ -22,6 +22,9 @@ class AccountAuthorityQueryTest < ActiveSupport::TestCase
   end
 
   test "#call provides results from the given network" do
+    VoteAccount.where(network: @network).each do |va|
+      va.update(authorized_voters: { "test_withdrawer_key2" => "test_withdrawer_value2" })
+    end
     res = AccountAuthorityQuery.new(network: @network).call
 
     assert_equal 5, res.count
@@ -29,6 +32,7 @@ class AccountAuthorityQueryTest < ActiveSupport::TestCase
   end
 
   test "#call provides results from the correct validator if validator param is provided" do
+    @vote_account.update(authorized_voters: { "test_withdrawer_key2" => "test_withdrawer_value2" })
     res = AccountAuthorityQuery.new(network: @network, validator: @validator.account).call
 
     assert_equal 1, res.count
@@ -36,6 +40,7 @@ class AccountAuthorityQueryTest < ActiveSupport::TestCase
   end
 
   test "#call provides results from the correct vote_account if vote_account param is provided" do
+    @vote_account.update(authorized_voters: { "test_withdrawer_key2" => "test_withdrawer_value2" })
     res = AccountAuthorityQuery.new(network: @network, vote_account: @vote_account.account).call
 
     assert_equal 1, res.count

--- a/test/queries/account_authority_query_test.rb
+++ b/test/queries/account_authority_query_test.rb
@@ -47,6 +47,13 @@ class AccountAuthorityQueryTest < ActiveSupport::TestCase
     assert_equal @vote_account, res.first.vote_account
   end
 
+  test "#call does no return record where only nil value changed" do
+    @vote_account.update(authorized_withdrawer: SecureRandom.hex(16))
+    res = AccountAuthorityQuery.new(network: @network, vote_account: @vote_account.account).call
+
+    assert_equal 0, res.count
+  end
+
   test "#call raises error when validator and vote_account params do not match" do
     assert_raises ArgumentError do
       AccountAuthorityQuery.new(


### PR DESCRIPTION
#### What's this PR do?
- authority changes with no real changes should not be displayed

#### How should this be manually tested?
- check authorities changes listed under vote_account details - those with nil before values or with no real changes should not be displayed

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185454134)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
