### PR TITLE
185636809 - redirect mainnet if incorrect network

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,6 @@ class ApplicationController < ActionController::Base
     I18n.with_locale(locale, &action)
   end
 
-  # app/controllers/application_controller.rb
   def default_url_options
     network = params[:network] ||= 'mainnet'
     { locale: I18n.locale, network: network }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_network
-    return if params[:network].present? && NETWORKS.include?(params[:network])
+    return if NETWORKS.include?(params[:network])
 
     params[:network] = "mainnet"
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_network
-    params[:network] ||= 'mainnet'
+    return if params[:network].present? && NETWORKS.include?(params[:network])
+
+    params[:network] = "mainnet"
   end
 
   protected

--- a/test/controllers/public_controller_test.rb
+++ b/test/controllers/public_controller_test.rb
@@ -14,6 +14,21 @@ class PublicControllerTest < ActionDispatch::IntegrationTest
     @admin_one = create(:user, :admin)
   end
 
+  test "root_url has mainnet network set as default if param is missing" do
+    get root_url
+    assert @controller.params[:network], "mainnet"
+  end
+
+  test "root_url has mainnet network set as default if param is invalid" do
+    get root_url(network: "fake_network")
+    assert @controller.params[:network], "mainnet"
+  end
+
+  test "root_url has custom network set if param is valid" do
+    get root_url(network: "testnet")
+    assert @controller.params[:network], "testnet"
+  end
+
   test "root_url leads to public#home" do
     get root_url(network: "testnet")
 


### PR DESCRIPTION
#### What's this PR do?
- set default network during incoming requests if param is missing or is incorrect.

#### How should this be manually tested?
- `rails test`
- enter any page and check scenarios
- - when network param is missing( mainnet should be rendered)
- - when network param passed in is valid( intendent network should be rendered)
- - network is invalid( mainnet should be rendered)

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185636809)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
