### PR TITLE
185697075 - remove deprecated set-output in github actions

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -62,13 +62,13 @@ jobs:
             ${{ runner.os }}-gems-
 
       - name: Get Yarn cache directory path
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache-dir
+        run: echo "path=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Setup cache key and directory for node_modules cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir.outputs.path }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-


### PR DESCRIPTION
#### What's this PR do?
- As in the title.

#### How should this be manually tested?
- Check for any deprecated warnings in github actions output.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/185697075)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
