### PR TITLE
186156556 handle errors in vote accounts daemon

### DIFF
--- a/app/services/gatherers/vote_account_details_service.rb
+++ b/app/services/gatherers/vote_account_details_service.rb
@@ -56,9 +56,10 @@ module Gatherers
     # -2 points if withdrawer and id are the same
     def update_score(vacc)
       return unless vacc
-      
+
       score = vacc.validator.validator_score_v1
-      
+      return unless score
+
       if vacc.validator_identity == vacc.authorized_withdrawer
         score.authorized_withdrawer_score = ValidatorScoreV1::WITHDRAWER_SCORE_OPTIONS[:negative]
       else

--- a/app/services/gatherers/vote_account_details_service.rb
+++ b/app/services/gatherers/vote_account_details_service.rb
@@ -61,7 +61,7 @@ module Gatherers
     def update_score(vacc)
       return unless vacc
 
-      score = vacc.validator.validator_score_v1
+      score = vacc.validator.score
       return unless score
 
       if vacc.validator_identity == vacc.authorized_withdrawer

--- a/app/services/gatherers/vote_account_details_service.rb
+++ b/app/services/gatherers/vote_account_details_service.rb
@@ -35,6 +35,10 @@ module Gatherers
     rescue ActiveRecord::LockWaitTimeout => e
       sleep 5
       retry
+    rescue StandardError => e
+      Appsignal.send_error(e)
+      sleep 5
+      retry
     end
 
     private

--- a/script/validators_get_avatar_url.rb
+++ b/script/validators_get_avatar_url.rb
@@ -35,7 +35,7 @@ NETWORKS.each do |network|
     # break # for development
     break if interrupted
   rescue StandardError => e
-    AppSignal.send_error(e)
+    Appsignal.send_error(e)
     next
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Fixes the error in gather_vote_accounts daemon for validators without scores
The problem is that the daemon is raising error for validators that don't have a score, and as a result daemon is restarted, starts processing from the beginning (mainnet) and never reaches testnet.
```
Oct 02 12:53:36 background.validators.app gather_vote_account_details_daemon[1887703]: NoMethodError
Oct 02 12:53:36 background.validators.app gather_vote_account_details_daemon[1887703]: undefined method `authorized_withdrawer_score=' for nil:NilClass
```

- Sends unexpected errors to Appsignal 

#### How should this be manually tested?
- Run `rails r daemons/gather_vote_account_details_daemon.rb` (you can edit line 9 to run for only one network) and confirm that it doesn't break. 
- On staging: wait until the gather script processes all networks and check https://stage.validators.app/validators/HvqQDoVtjmDQD13F3FrDypBfpjrBiiGTJYF4MvYE5qQC?locale=en&network=testnet Confirm that "withdrawer authority" warning disappeared.

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186156556)

#### Task completed checklist:
- [Y] Is there appropriate test coverage?
- [Y] Did I take into consideration possible security vulnerabilities?
- [Y] Are the controllers secure?
- [Y] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
