### PR TITLE
186133556-set-audits-retention-time

### DIFF
--- a/app/models/explorer_stake_account.rb
+++ b/app/models/explorer_stake_account.rb
@@ -30,5 +30,5 @@
 #  index_explorer_stake_accounts_on_withdrawer_and_network    (withdrawer,network)
 #
 class ExplorerStakeAccount < ApplicationRecord
-  audited
+  audited except: [:created_at, :updated_at, :epoch]
 end

--- a/script/prune_database_tables.rb
+++ b/script/prune_database_tables.rb
@@ -40,3 +40,6 @@ ValidatorScoreV1.where("active_stake IS NULL and created_at < '#{sixty_days_ago}
                   # score.validator.vote_accounts
                   score.validator.destroy
                 end
+
+# remove old audit records (from explorer stake accounts)
+Audited::Audit.where("created_at < ?", sixty_days_ago).destroy_all


### PR DESCRIPTION
#### What's this PR do?
- remove audits after 60 days
- exclude created_at, updated_at, epoch from being audited

#### How should this be manually tested?
- run `rails r script/gather_stake_accounts.rb` and then `rails r script/gather_explorer_stake_accounts.rb`
- run `rails r script/prune_database_tables.rb`

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186133556)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
