### PR TITLE
186181863 move group workers to separate queue

### DIFF
--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -81,7 +81,7 @@ class VoteAccount < ApplicationRecord
   end
 
   def check_group_assignment
-    CheckGroupValidatorAssignmentWorker.perform_async({
+    CheckGroupValidatorAssignmentWorker.set(queue: :low_priority).perform_async({
       vote_account_id: self.id
     })
   end

--- a/config/sidekiq.yml.example
+++ b/config/sidekiq.yml.example
@@ -9,3 +9,4 @@ development:
   - high_priority
   - default
   - low_priority
+  - lowest_priority


### PR DESCRIPTION
#### What's this PR do?
- Moves CheckGroupValidatorAssignmentWorker to low priority queue

#### How should this be manually tested?
- Run sidekiq
- Run daemons/gather_vote_account_details_daemon.rb and confirm that workers are added to low_priority queue

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186181863)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
