### PR TITLE
186183228-fix-prune-db-script

### DIFF
--- a/app/models/vote_account.rb
+++ b/app/models/vote_account.rb
@@ -35,7 +35,7 @@ class VoteAccount < ApplicationRecord
 
   belongs_to :validator
   has_many :vote_account_histories
-  has_many :account_authority_histories
+  has_many :account_authority_histories, dependent: :destroy
   before_save :set_network
   after_save do
     if saved_change_to_authorized_withdrawer? || authorized_voters_value_changed?

--- a/script/prune_database_tables.rb
+++ b/script/prune_database_tables.rb
@@ -19,26 +19,26 @@ ValidatorScoreV1.where("active_stake = 0 and created_at < '#{sixty_days_ago}'")
                 .each do |score|
                   puts "#{score.validator.account} (#{score.network})" \
                     if verbose
-                  if score.validator&.vote_account_histories.count > 0
+                  if score.validator && score.validator.vote_account_histories.count > 0
                     puts "  Skipping due to non-empty vote_account_histories"
                     next
                   end
                   # score.validator.vote_account_histories.destroy_all
                   # score.validator.vote_accounts
-                  score.validator.destroy
+                  score.validator&.destroy
                 end
 
 ValidatorScoreV1.where("active_stake IS NULL and created_at < '#{sixty_days_ago}'")
                 .each do |score|
                   puts "#{score.validator.account} (#{score.network})" \
                     if verbose
-                  if score.validator&.vote_account_histories.count > 0
+                  if score.validator && score.validator.vote_account_histories.count > 0
                     puts "  Skipping due to non-empty vote_account_histories"
                     next
                   end
                   # score.validator.vote_account_histories.destroy_all
                   # score.validator.vote_accounts
-                  score.validator.destroy
+                  score.validator&.destroy
                 end
 
 # remove old audit records (from explorer stake accounts)

--- a/script/prune_database_tables.rb
+++ b/script/prune_database_tables.rb
@@ -19,7 +19,7 @@ ValidatorScoreV1.where("active_stake = 0 and created_at < '#{sixty_days_ago}'")
                 .each do |score|
                   puts "#{score.validator.account} (#{score.network})" \
                     if verbose
-                  if score.validator.vote_account_histories.count > 0
+                  if score.validator&.vote_account_histories.count > 0
                     puts "  Skipping due to non-empty vote_account_histories"
                     next
                   end
@@ -32,7 +32,7 @@ ValidatorScoreV1.where("active_stake IS NULL and created_at < '#{sixty_days_ago}
                 .each do |score|
                   puts "#{score.validator.account} (#{score.network})" \
                     if verbose
-                  if score.validator.vote_account_histories.count > 0
+                  if score.validator&.vote_account_histories.count > 0
                     puts "  Skipping due to non-empty vote_account_histories"
                     next
                   end


### PR DESCRIPTION
#### What's this PR do?
- add lacking dependent: destroy to avoid foreign key constraint failure

#### How should this be manually tested?
- find validator with account_authority_histories
- set validator created_at older than 60 days
- remove all vote account histories for it and set active stake to 0
- run `rails r script/prune_database_tables.rb` and check if validator has been deleted without errors

#### What are the relevant tickets?
- URL to the PivotalTracker ticket

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
