### PR TITLE
186486202 - add top records in explorer stake account page

### DIFF
--- a/app/controllers/concerns/stake_accounts_controller_helper.rb
+++ b/app/controllers/concerns/stake_accounts_controller_helper.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 module StakeAccountsControllerHelper
-  def get_explorer_stake_accounts(params:)
+  def get_explorer_stake_accounts(params:, limit_count: nil)
     @explorer_stake_accounts = ExplorerStakeAccountQuery.new(
       vote_account: params[:vote_account],
       withdrawer: params[:withdrawer],
       staker: params[:staker],
       stake_pubkey: params[:stake_pubkey], 
-      network: params[:network]
+      network: params[:network],
+      limit_count: limit_count
     ).call(page: params[:page], per: params[:per])
 
     @stake_accounts = StakeAccount.where(

--- a/app/controllers/explorer_stake_accounts_controller.rb
+++ b/app/controllers/explorer_stake_accounts_controller.rb
@@ -4,6 +4,7 @@ class ExplorerStakeAccountsController < ApplicationController
   include StakeAccountsControllerHelper
 
   AUDITS_FILTERS = %w[active_stake account_balance credits_observed deactivating_stake delegated_stake rent_exempt_reserve].freeze
+  TOP_LIMIT_COUNT = 20
 
   def index
     if index_params[:staker].present? || \
@@ -11,11 +12,16 @@ class ExplorerStakeAccountsController < ApplicationController
        index_params[:vote_account].present? || \
        index_params[:stake_pubkey].present?
       @explorer_stake_accounts, @stake_accounts = get_explorer_stake_accounts(params: index_params)
-      @explorer_stake_accounts = @explorer_stake_accounts[:explorer_stake_accounts]
-   end
+    else
+      @explorer_stake_accounts, @stake_accounts = get_explorer_stake_accounts(
+        params: index_params, limit_count: TOP_LIMIT_COUNT
+      )
+    end
+
+    @explorer_stake_accounts = @explorer_stake_accounts[:explorer_stake_accounts]
   end
 
-  def show  
+  def show
     @explorer_stake_account = ExplorerStakeAccount.find_by(
       stake_pubkey: params[:stake_pubkey],
       network: params[:network]

--- a/test/controllers/explorer_stake_accounts_controller_test.rb
+++ b/test/controllers/explorer_stake_accounts_controller_test.rb
@@ -16,18 +16,18 @@ class ExplorerStakeAccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'assigns explorer_stake_accounts variable' do
-    get explorer_stake_accounts_url(network: 'testnet')
+  test "assigns explorer_stake_accounts variable" do
+    get explorer_stake_accounts_url(network: "testnet")
     assert_equal @explorer_stake_accounts.sort_by(&:delegated_stake).reverse.first(20),
-      @controller.view_assigns['explorer_stake_accounts']
+      @controller.view_assigns["explorer_stake_accounts"]
   end
 
-  test 'assigns explorer_stake_accounts variable when filters presented' do
+  test "assigns explorer_stake_accounts variable when filters presented" do
     get explorer_stake_accounts_url(
-      network: 'testnet', staker: 'staker', stake_pubkey: 'stake_pubkey',
-      delegated_vote_account_address: 'vote_account_address'
+      network: "testnet", staker: "staker", stake_pubkey: "stake_pubkey",
+      delegated_vote_account_address: "vote_account_address"
     )
     assert_equal @explorer_stake_accounts.sort_by(&:delegated_stake).reverse.first(25),
-      @controller.view_assigns['explorer_stake_accounts']
+      @controller.view_assigns["explorer_stake_accounts"]
   end
 end

--- a/test/controllers/explorer_stake_accounts_controller_test.rb
+++ b/test/controllers/explorer_stake_accounts_controller_test.rb
@@ -3,8 +3,31 @@
 require "test_helper"
 
 class ExplorerStakeAccountsControllerTest < ActionDispatch::IntegrationTest
+
+  setup do
+    epoch_wall_clock = create(:epoch_wall_clock)
+    @explorer_stake_accounts = (1000..1050).map do |stake|
+      create(:explorer_stake_account, delegated_stake: stake, epoch: epoch_wall_clock.epoch)
+    end
+  end
+
   test "should get index" do
     get explorer_stake_accounts_url
     assert_response :success
+  end
+
+  test 'assigns explorer_stake_accounts variable' do
+    get explorer_stake_accounts_url(network: 'testnet')
+    assert_equal @explorer_stake_accounts.sort_by(&:delegated_stake).reverse.first(20),
+      @controller.view_assigns['explorer_stake_accounts']
+  end
+
+  test 'assigns explorer_stake_accounts variable when filters presented' do
+    get explorer_stake_accounts_url(
+      network: 'testnet', staker: 'staker', stake_pubkey: 'stake_pubkey',
+      delegated_vote_account_address: 'vote_account_address'
+    )
+    assert_equal @explorer_stake_accounts.sort_by(&:delegated_stake).reverse.first(25),
+      @controller.view_assigns['explorer_stake_accounts']
   end
 end

--- a/test/queries/explorer_stake_account_query_test.rb
+++ b/test/queries/explorer_stake_account_query_test.rb
@@ -77,4 +77,13 @@ class ExplorerStakeAccountQueryTest < ActiveSupport::TestCase
     assert_equal ["test_delegated_vote_account_address_2", "test_delegated_vote_account_address_6"], explorer_stake_accounts.pluck(:delegated_vote_account_address)
     assert_equal 2, explorer_stake_accounts.count
   end
+
+  test "service returns correct amount of records when limit_count presented" do
+    explorer_stake_account = ExplorerStakeAccountQuery.new(
+      network: @network,
+      limit_count: 3
+    ).call[:explorer_stake_accounts]
+
+    assert_equal 3, explorer_stake_account.count
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
- Adds top 20 stake accounts ordered by delegated stake.

#### How should this be manually tested?
- make sure you have db populated with explorer stake accounts
- at stake explorer page when filters are reseted (filters are blank) the table should include only 20 of top stake accounts records ordered by stake
- enter some values to the filters and check if that works as usual (the output should be paginated)
- if both filters and stake accounts are absent then the page should include content "Use the filters above to see Stake Accounts."
- if filters are presented, but stake accounts are missing for the criteria then there should an information "No results for given criteria." included.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186486202)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
