### PR TITLE
186775243 update jito logic

### DIFF
--- a/app/javascript/packs/mixins/validators_mixins.js
+++ b/app/javascript/packs/mixins/validators_mixins.js
@@ -44,6 +44,14 @@ Vue.mixin({
       } else {
         return defaultAvatar
       }
+    },
+
+    jito_maximum_commission(validator) {
+      if(validator['jito'] && parseInt(validator['jito_commission']) <= 1000) {
+        return true
+      } else {
+        return false
+      }
     }
   }
 })

--- a/app/javascript/packs/validators/validator_details.vue
+++ b/app/javascript/packs/validators/validator_details.vue
@@ -165,7 +165,7 @@
                 </td>
               </tr>
 
-              <tr v-if="validator.stake_pools_list.length > 0 || validator.jito">
+              <tr v-if="validator.stake_pools_list.length > 0 || jito_maximum_commission(validator)">
                 <td><strong>Stake Pools:</strong></td>
                 <td>
                   <span v-for="stake_pool_name in validator.stake_pools_list">
@@ -174,7 +174,7 @@
                          :alt="stake_pool_name"
                          :src="stake_pool_small_logo(stake_pool_name)" />
                   </span>
-                  <img :src="jito_badge" class="img-xxs ms-1" title="Jito validator" v-if="validator.jito">
+                  <img :src="jito_badge" class="img-xxs ms-1" title="Jito validator" v-if="jito_maximum_commission(validator)">
                 </td>
               </tr>
 
@@ -365,9 +365,9 @@
         })
       },
 
-      reload_validator_data(){
+      reload_validator_data() {
         setTimeout( () => {
-          if(this.live){
+          if(this.live) {
             this.get_validator_data()
           }
           this.reload_validator_data()

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -58,6 +58,8 @@ class Validator < ApplicationRecord
 
   DEFAULT_FILTERS = %w(active private delinquent).freeze
 
+  MAXIMUM_JITO_COMMISSION = 1000.freeze
+
   has_many :vote_accounts, dependent: :destroy
   has_many :account_authority_histories, through: :vote_accounts, dependent: :destroy
   has_many :stake_accounts, dependent: :destroy
@@ -89,6 +91,7 @@ class Validator < ApplicationRecord
   scope :active, -> { where(is_active: true, is_destroyed: false) }
   scope :scorable, -> { where(is_active: true, is_rpc: false, is_destroyed: false) }
   scope :for_api, -> { select(FIELDS_FOR_API) }
+  scope :jito_maximum_commission, -> { where(jito: true).where("jito_commission <= ?", MAXIMUM_JITO_COMMISSION) }
 
   serialize :stake_pools_list, Array, default: []
 
@@ -326,7 +329,7 @@ class Validator < ApplicationRecord
 
   def jito_maximum_commission?
     return false unless jito
-    (jito_commission.to_i / 100) <= 10
+    jito_commission.to_i <= MAXIMUM_JITO_COMMISSION
   end
 
   def api_url

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -49,6 +49,7 @@ class Validator < ApplicationRecord
     www_url
     admin_warning
     jito
+    jito_commission
     stake_pools_list
     is_active
   ].freeze
@@ -321,6 +322,11 @@ class Validator < ApplicationRecord
 
   def private_validator?
     score&.commission == 100 && network == 'mainnet'
+  end
+
+  def jito_maximum_commission?
+    return false unless jito
+    (jito_commission.to_i / 100) <= 10
   end
 
   def api_url

--- a/app/queries/validator_query.rb
+++ b/app/queries/validator_query.rb
@@ -68,7 +68,7 @@ class ValidatorQuery < ApplicationQuery
   end
 
   def filter_by_collaboration(scope, jito)
-    scope = jito ? scope.where(jito: true) : scope
+    scope = jito ? scope.jito_maximum_commission : scope
   end
 
   def filter_by_network(scope, network)

--- a/app/views/validators/_table.html.erb
+++ b/app/views/validators/_table.html.erb
@@ -178,7 +178,7 @@
                   <% end %>
                 </div>
               <% end %>
-              <% if validator.jito %>
+              <% if validator.jito_maximum_commission? %>
                 <div class="mt-2 mt-lg-0 d-inline-block">
                   <%= link_to validators_path(network: params[:network], jito: params[:jito]) do %>
                     <%= image_tag("jito.svg", class: 'img-xxs me-1', title: "Show Jito validators", alt: "J") %>

--- a/test/models/validator_test.rb
+++ b/test/models/validator_test.rb
@@ -123,11 +123,17 @@ class ValidatorTest < ActiveSupport::TestCase
     @validator.update(jito: false)
     refute @validator.jito_maximum_commission?
 
+    @validator.update(jito: false, jito_commission: nil)
+    refute @validator.jito_maximum_commission?
+
+    @validator.update(jito: true, jito_commission: nil)
+    assert @validator.jito_maximum_commission?
+
     @validator.update(jito: true, jito_commission: 800)
-    assert true, @validator.jito_maximum_commission?
+    assert @validator.jito_maximum_commission?
 
     @validator.update(jito: true, jito_commission: 1000)
-    assert true, @validator.jito_maximum_commission?
+    assert @validator.jito_maximum_commission?
 
     @validator.update(jito: true, jito_commission: 1100)
     refute @validator.jito_maximum_commission?

--- a/test/models/validator_test.rb
+++ b/test/models/validator_test.rb
@@ -119,6 +119,20 @@ class ValidatorTest < ActiveSupport::TestCase
     refute create(:validator_score_v1, commission: 99, validator: @validator).validator.private_validator?
   end
 
+  test "#jito_maximum_commission? returns true if validator is jito and jito commission is below or equal 10%" do
+    @validator.update(jito: false)
+    refute @validator.jito_maximum_commission?
+
+    @validator.update(jito: true, jito_commission: 800)
+    assert true, @validator.jito_maximum_commission?
+
+    @validator.update(jito: true, jito_commission: 1000)
+    assert true, @validator.jito_maximum_commission?
+
+    @validator.update(jito: true, jito_commission: 1100)
+    refute @validator.jito_maximum_commission?
+  end
+
   test "validator attributes are correctly stored in db after using utf_8_encode method" do
     special_chars_sentence = "Staking-P◎◎l FREE Validati◎n"
 

--- a/test/queries/validator_query_test.rb
+++ b/test/queries/validator_query_test.rb
@@ -41,7 +41,7 @@ class ValidatorQueryTest < ActiveSupport::TestCase
     assert_equal [@mainnet_network], result.pluck(:network).uniq
   end
 
-  test "#call returns only jito validators if jito param is provided" do
+  test "#call returns only jito validators with commission below maximum, if jito param is provided" do
     create_list(
       :validator,
       2,
@@ -55,7 +55,17 @@ class ValidatorQueryTest < ActiveSupport::TestCase
       :with_score,
       :with_data_center_through_validator_ip,
       :mainnet,
-      jito: true
+      jito: true,
+      jito_commission: 800
+    )
+    create_list(
+      :validator,
+      1,
+      :with_score,
+      :with_data_center_through_validator_ip,
+      :mainnet,
+      jito: true,
+      jito_commission: 1100
     )
 
     result = ValidatorQuery.new.call(network: @mainnet_network, query_params: { jito: true })


### PR DESCRIPTION
#### What's this PR do?
- Displays jito badge only if jito commission is below maximum
- Updates jito filter to only return validators with commission below maximum
- Always displays jito commission for jito validators

#### How should this be manually tested?
- Use "jito" filter on home page, and confirm that validators with high jito commission are not returned (eg. Shinobi -  Ninja1spj6n9t5hVYgF3PdnYz2PLnkt7rvaw3firmjs)
- Confirm that jito badge is not displayed
- Confirm that jito commission on details page is still displayed

![image](https://github.com/brianlong/www.validators.app/assets/32059143/1a19f22a-7d81-4ba2-8fe0-de947ed14c45)


#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186775243)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
