### PR TITLE
186818750 moving average for skipped after

### DIFF
--- a/app/javascript/packs/validators/charts/skipped_after_chart.js
+++ b/app/javascript/packs/validators/charts/skipped_after_chart.js
@@ -16,20 +16,23 @@ export default {
   methods: {},
 
   data() {
+    console.log(this.validator)
     var skipped_after_vl = Math.min.apply(Math, [60, this.validator['skipped_after_history'].length])
-    var skipped_after_ma = Math.min.apply(Math, [60, this.validator['skipped_slot_after_moving_average_history'].length])
-    var skipped_after_ma_vector = this.validator['skipped_slot_after_moving_average_history'].slice(Math.max(this.validator['skipped_slot_after_moving_average_history'].length - skipped_after_ma, 0))
-    var skipped_after_vector = this.validator['skipped_after_history'].slice(Math.max(this.validator['skipped_slot_history'].length - skipped_after_vl, 0))
+    var skipped_after_ma = Math.min.apply(Math, [60, this.validator['skipped_after_moving_average_history'].length])
+    var skipped_after_ma_vector = this.validator['skipped_after_moving_average_history'].slice(Math.max(this.validator['skipped_after_moving_average_history'].length - skipped_after_ma, 0))
+    var skipped_after_vector = this.validator['skipped_after_history'].slice(Math.max(this.validator['skipped_after_history'].length - skipped_after_vl, 0))
     skipped_after_vector.forEach(function(part, index) {
       this[index] = part * 100;
     }, skipped_after_vector)
     skipped_after_ma_vector.forEach(function(part, index) {
       this[index] = part * 100;
     }, skipped_after_ma_vector)
+
+    var skipped_after_score = 2 // TODO change this after adding the score to the validator API
     return {
       skipped_after_distance_chart: {
-        line_color: this.$parent.chart_line_color(this.validator['skipped_slot_score']),
-        fill_color: this.$parent.chart_fill_color(this.validator['skipped_slot_score']),
+        line_color: this.$parent.chart_line_color(skipped_after_score),
+        fill_color: this.$parent.chart_fill_color(skipped_after_score),
         vector: skipped_after_vector,
         moving_avg_vector: skipped_after_ma_vector
       }

--- a/app/javascript/packs/validators/charts/skipped_after_chart.js
+++ b/app/javascript/packs/validators/charts/skipped_after_chart.js
@@ -16,7 +16,6 @@ export default {
   methods: {},
 
   data() {
-    console.log(this.validator)
     var skipped_after_vl = Math.min.apply(Math, [60, this.validator['skipped_after_history'].length])
     var skipped_after_ma = Math.min.apply(Math, [60, this.validator['skipped_after_moving_average_history'].length])
     var skipped_after_ma_vector = this.validator['skipped_after_moving_average_history'].slice(Math.max(this.validator['skipped_after_moving_average_history'].length - skipped_after_ma, 0))

--- a/app/logic/validator_score_v1_logic.rb
+++ b/app/logic/validator_score_v1_logic.rb
@@ -246,6 +246,7 @@ module ValidatorScoreV1Logic
         SELECT vbh.validator_id,
                vbh.skipped_slot_percent,
                vbh.skipped_slot_percent_moving_average,
+               vbh.skipped_slot_after_percent_moving_average,
                vbh.skipped_slots_after_percent
         FROM validator_block_histories vbh
         WHERE vbh.network = '#{p.payload[:network]}' AND vbh.batch_uuid = '#{p.payload[:batch_uuid]}'
@@ -261,11 +262,13 @@ module ValidatorScoreV1Logic
         skipped_slot_percent = last_validator_block_history_for_validator[1]
         validator.score.skipped_slot_history_push(skipped_slot_percent.to_f)
         validator.validator_score_v1.skipped_after_history_push(
-          last_validator_block_history_for_validator[3].to_f
+          last_validator_block_history_for_validator[4].to_f
         )
 
-        moving_average = last_validator_block_history_for_validator[2]
-        validator.score.skipped_slot_moving_average_history_push(moving_average.to_f)
+        slots_moving_average = last_validator_block_history_for_validator[2]
+        after_moving_average = last_validator_block_history_for_validator[3]
+        validator.score.skipped_slot_moving_average_history_push(slots_moving_average.to_f)
+        validator.score.skipped_after_moving_average_history_push(after_moving_average.to_f)
       rescue StandardError => e
         Appsignal.send_error(e)
       end

--- a/app/models/validator_block_history.rb
+++ b/app/models/validator_block_history.rb
@@ -4,20 +4,21 @@
 #
 # Table name: validator_block_histories
 #
-#  id                                  :bigint           not null, primary key
-#  batch_uuid                          :string(191)
-#  blocks_produced                     :integer
-#  epoch                               :integer
-#  leader_slots                        :integer
-#  network                             :string(191)
-#  skipped_slot_percent                :decimal(10, 4)
-#  skipped_slot_percent_moving_average :decimal(10, 4)
-#  skipped_slots                       :integer
-#  skipped_slots_after                 :integer
-#  skipped_slots_after_percent         :decimal(10, 4)
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  validator_id                        :bigint           not null
+#  id                                        :bigint           not null, primary key
+#  batch_uuid                                :string(191)
+#  blocks_produced                           :integer
+#  epoch                                     :integer
+#  leader_slots                              :integer
+#  network                                   :string(191)
+#  skipped_slot_after_percent_moving_average :decimal(10, 4)
+#  skipped_slot_percent                      :decimal(10, 4)
+#  skipped_slot_percent_moving_average       :decimal(10, 4)
+#  skipped_slots                             :integer
+#  skipped_slots_after                       :integer
+#  skipped_slots_after_percent               :decimal(10, 4)
+#  created_at                                :datetime         not null
+#  updated_at                                :datetime         not null
+#  validator_id                              :bigint           not null
 #
 # Indexes
 #
@@ -48,7 +49,7 @@ class ValidatorBlockHistory < ApplicationRecord
 
   scope :for_batch, ->(network, batch_uuid) { where(network: network, batch_uuid: batch_uuid) }
 
-  after_create :set_skipped_slot_percent_moving_average
+  after_create :set_moving_averages
 
   # returns other ValidatorBlockHistory records created within the last 24 hours of `self`
   def previous_24_hours
@@ -57,8 +58,9 @@ class ValidatorBlockHistory < ApplicationRecord
 
   private
 
-  def set_skipped_slot_percent_moving_average
+  def set_moving_averages
     self.skipped_slot_percent_moving_average = previous_24_hours.average(:skipped_slot_percent)
+    self.skipped_slot_after_percent_moving_average = previous_24_hours.average(:skipped_slots_after_percent)
     save
   end
 end

--- a/app/models/validator_score_v1.rb
+++ b/app/models/validator_score_v1.rb
@@ -33,6 +33,7 @@
 #  root_distance_score                         :integer
 #  security_report_score                       :integer
 #  skipped_after_history                       :text(65535)
+#  skipped_after_moving_average_history        :text(65535)
 #  skipped_after_score                         :integer
 #  skipped_slot_history                        :text(65535)
 #  skipped_slot_moving_average_history         :text(65535)
@@ -88,6 +89,7 @@ class ValidatorScoreV1 < ApplicationRecord
     skipped_slot_history
     skipped_vote_history
     skipped_slot_moving_average_history
+    skipped_after_moving_average_history
     stake_concentration
     skipped_after_history
   ].freeze
@@ -117,6 +119,7 @@ class ValidatorScoreV1 < ApplicationRecord
   serialize :skipped_vote_history, JSON
   serialize :skipped_vote_percent_moving_average_history, JSON
   serialize :skipped_slot_moving_average_history, JSON
+  serialize :skipped_after_moving_average_history, JSON
 
   delegate :data_center, to: :validator, prefix: true, allow_nil: true
 
@@ -311,6 +314,16 @@ class ValidatorScoreV1 < ApplicationRecord
 
     if skipped_slot_moving_average_history.length > MAX_HISTORY
       self.skipped_slot_moving_average_history = skipped_slot_moving_average_history[-MAX_HISTORY..-1]
+    end
+  end
+
+  def skipped_after_moving_average_history_push(val)
+    self.skipped_after_moving_average_history = [] if skipped_after_moving_average_history.nil?
+
+    skipped_after_moving_average_history << val
+
+    if skipped_after_moving_average_history.length > MAX_HISTORY
+      self.skipped_after_moving_average_history = skipped_after_moving_average_history[-MAX_HISTORY..-1]
     end
   end
 

--- a/app/views/validators/_table.html.erb
+++ b/app/views/validators/_table.html.erb
@@ -331,6 +331,7 @@
           line_color = chart_line_color(validator.skipped_slot_score)
         %>
         <%= render 'validators/validator_skipped_slots_chart',
+                   chart_name: "skipped_slots_#{validator.account}",
                    account: validator.account,
                    vector: slot_vector,
                    line_color: line_color,
@@ -342,23 +343,19 @@
       <td class="column-chart d-none d-lg-table-cell" id="skipped-after-<%=i%>">
         <%
           vl = chart_x_scale(validator.score&.skipped_after_history.to_a.count)
-          line_color = chart_line_color(validator.skipped_after_score)
-          fill_color = chart_fill_color(validator.skipped_after_score)
-          vector = validator.score&.skipped_after_history.to_a[-vl..-1].map { |v| (v.to_f*100.0).round(1) }
+          ma = chart_x_scale(validator.score&.skipped_after_moving_average_history.to_a.count)
+
+          skipped_slots_moving_avg = validator.score&.skipped_after_moving_average_history.to_a[-ma..-1]&.map { |v| (v.to_f*100.0).round(1) }
+          slot_vector = validator.score&.skipped_after_history.to_a[-vl..-1].map { |v| (v.to_f*100.0).round(1) }
+
+          line_color = chart_line_color(validator.skipped_slot_score)
         %>
-        <% max_value = vector&.max %>
-        <% if max_value && max_value > Y_SKIPPED_AFTER_MAX %>
-          <div class="chart-top-container">
-            <div class="chart-top-value" style="left: <%= max_value_position(vector) %>">
-              <%= max_value %>
-            </div>
-          </div>
-        <% end %>
-        <%= render 'validators/validator_small_chart',
+        <%= render 'validators/validator_skipped_slots_chart',
                    chart_name: "skipped_after_#{validator.account}",
-                   vector: vector,
+                   account: validator.account,
+                   vector: slot_vector,
                    line_color: line_color,
-                   fill_color: fill_color
+                   moving_avg_vector: skipped_slots_moving_avg
         %>
       </td>
     </tr>

--- a/app/views/validators/_table.html.erb
+++ b/app/views/validators/_table.html.erb
@@ -348,7 +348,7 @@
           skipped_slots_moving_avg = validator.score&.skipped_after_moving_average_history.to_a[-ma..-1]&.map { |v| (v.to_f*100.0).round(1) }
           slot_vector = validator.score&.skipped_after_history.to_a[-vl..-1].map { |v| (v.to_f*100.0).round(1) }
 
-          line_color = chart_line_color(validator.skipped_slot_score)
+          line_color = chart_line_color(2) # TODO: change to validator.skipped_slot_score after adding skipped_after_score to API
         %>
         <%= render 'validators/validator_skipped_slots_chart',
                    chart_name: "skipped_after_#{validator.account}",

--- a/app/views/validators/_validator_skipped_slots_chart.html.erb
+++ b/app/views/validators/_validator_skipped_slots_chart.html.erb
@@ -1,6 +1,6 @@
-<canvas id="skipped_slots_<%= local_assigns[:account] %>"></canvas>
+<canvas id="<%= local_assigns[:chart_name] %>"></canvas>
 <script type="text/javascript">
-    var ctx = document.getElementById("skipped_slots_<%= local_assigns[:account] %>").getContext('2d');
+    var ctx = document.getElementById("<%= local_assigns[:chart_name] %>").getContext('2d');
     var chart = new Chart(ctx, {
         type: 'line',
         data: {

--- a/db/migrate/20240112091915_add_skipped_after_percent_moving_average_to_validator_block_histories.rb
+++ b/db/migrate/20240112091915_add_skipped_after_percent_moving_average_to_validator_block_histories.rb
@@ -1,0 +1,5 @@
+class AddSkippedAfterPercentMovingAverageToValidatorBlockHistories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :validator_block_histories, :skipped_slot_after_percent_moving_average, :decimal, precision: 10, scale: 4
+  end
+end

--- a/db/migrate/20240112111301_add_skipped_after_moving_average_history_to_validator_score_v1.rb
+++ b/db/migrate/20240112111301_add_skipped_after_moving_average_history_to_validator_score_v1.rb
@@ -1,0 +1,5 @@
+class AddSkippedAfterMovingAverageHistoryToValidatorScoreV1 < ActiveRecord::Migration[6.1]
+  def change
+    add_column :validator_score_v1s, :skipped_after_moving_average_history, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_19_093003) do
+ActiveRecord::Schema.define(version: 2024_01_12_091915) do
 
   create_table "account_authority_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "authorized_withdrawer_before"
@@ -580,6 +580,7 @@ ActiveRecord::Schema.define(version: 2023_12_19_093003) do
     t.decimal "skipped_slots_after_percent", precision: 10, scale: 4
     t.string "network"
     t.decimal "skipped_slot_percent_moving_average", precision: 10, scale: 4
+    t.decimal "skipped_slot_after_percent_moving_average", precision: 10, scale: 4
     t.index ["network", "batch_uuid"], name: "index_validator_block_histories_on_network_and_batch_uuid"
     t.index ["validator_id", "created_at"], name: "index_validator_block_histories_on_validator_id_and_created_at"
     t.index ["validator_id", "epoch"], name: "index_validator_block_histories_on_validator_id_and_epoch"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_12_091915) do
+ActiveRecord::Schema.define(version: 2024_01_12_111301) do
 
   create_table "account_authority_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "authorized_withdrawer_before"
@@ -679,6 +679,7 @@ ActiveRecord::Schema.define(version: 2024_01_12_091915) do
     t.text "skipped_vote_percent_moving_average_history"
     t.integer "authorized_withdrawer_score"
     t.integer "consensus_mods_score", default: 0
+    t.text "skipped_after_moving_average_history"
     t.index ["network", "active_stake", "commission", "delinquent"], name: "index_for_asns"
     t.index ["network", "total_score"], name: "index_validator_score_v1s_on_network_and_total_score"
     t.index ["network", "validator_id"], name: "index_validator_score_v1s_on_network_and_validator_id"

--- a/test/controllers/api/v1/validators_controller_test.rb
+++ b/test/controllers/api/v1/validators_controller_test.rb
@@ -501,7 +501,7 @@ class ValidatorsControllerTest < ActionDispatch::IntegrationTest
     validator_active_stake = validator.validator_score_v1.active_stake
 
     # Adjust after adding/removing attributes in json builder
-    assert_equal 46, json_response.keys.size
+    assert_equal 47, json_response.keys.size
 
     # Score
     assert_equal [1, 2, 3, 4, 5], json_response["root_distance_history"]

--- a/test/models/validator_block_history_test.rb
+++ b/test/models/validator_block_history_test.rb
@@ -24,6 +24,18 @@ class ValidatorBlockHistoryTest < ActiveSupport::TestCase
     assert_equal(0.375, vbh4.skipped_slot_percent_moving_average)
   end
 
+  test 'after_create, #skipped_slot_after_percent_moving_average is calculated as the moving average for the last 24 hours' do
+    vbh1 = create(:validator_block_history, validator: @validator, skipped_slots_after_percent: 0)
+    vbh2 = create(:validator_block_history, validator: @validator, skipped_slots_after_percent: 0.25)
+    vbh3 = create(:validator_block_history, validator: @validator, skipped_slots_after_percent: 0.5)
+    vbh4 = create(:validator_block_history, validator: @validator, skipped_slots_after_percent: 0.75)
+
+    assert_equal(0, vbh1.skipped_slot_after_percent_moving_average)
+    assert_equal(0.125, vbh2.skipped_slot_after_percent_moving_average)
+    assert_equal(0.25, vbh3.skipped_slot_after_percent_moving_average)
+    assert_equal(0.375, vbh4.skipped_slot_after_percent_moving_average)
+  end
+
   test 'has_one batch relationship works correctly' do
     batch = create(:batch)
     vbhs = create_list(:validator_block_history, 3, batch_uuid: batch.uuid)


### PR DESCRIPTION
#### What's this PR do?
- add moving average for skipped after

#### How should this be manually tested?
- run migrations
- run tests
- run gather and score daemons
- check if skipped_after_moving_average is present in validator_block_histories
- check if skipped_after_moving_average_history is present in scores
- check if charts are valid in validator index and other pages

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186818750)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [Y] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
