### PR TITLE
186811096 - remove old validator

### DIFF
--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -592,10 +592,11 @@ module SolanaLogic
       return p unless p[:code] == 200
 
       p.payload[:validators_info].each do |result|
-        validator = Validator.find_or_create_by(
+        validator = Validator.find_by(
           network: p.payload[:network],
           account: result['identityPubkey']
         )
+        next unless validator
 
         utf_8_name = result['info']['name'].to_s.encode_utf_8.strip
         validator.name = utf_8_name unless utf_8_name.to_s.downcase.include?('script')

--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -63,6 +63,7 @@ class Validator < ApplicationRecord
   has_many :vote_accounts, dependent: :destroy
   has_many :account_authority_histories, through: :vote_accounts, dependent: :destroy
   has_many :stake_accounts, dependent: :destroy
+  has_many :stake_account_histories, dependent: :destroy
   has_many :vote_account_histories, through: :vote_accounts, dependent: :destroy
   has_many :validator_ips, dependent: :nullify
   has_many :validator_block_histories, dependent: :destroy

--- a/script/one_time_scripts/remove_validator.rb
+++ b/script/one_time_scripts/remove_validator.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-network = ARGV[0]
-account = ARGV[1]
+@network ||= ARGV[0]
+@account ||= ARGV[1]
 
 # raise "invalid network - #{network}" unless NETWORKS.include? network
 
-validator = Validator.find_by(account: account, network: network)
+validator = Validator.find_by(account: @account, network: @network)
 
-raise "validator not found (#{account})" unless validator
+raise "validator not found (#{@account})" unless validator
 
 puts "found validator with id: #{validator.id}"
 
@@ -29,18 +29,20 @@ ActiveRecord::Base.transaction do
   validator.user_watchlist_elements.delete_all
   validator.delete
 
-  puts "validator_histories deleted"
-  puts "validator_block_histories deleted"
-  puts "account_authority_histories deleted"
-  puts "vote_account_histories deleted"
-  puts "vote_accounts deleted"
-  puts "commission_histories deleted"
-  puts "stake_account_histories deleted"
-  puts "stake_accounts deleted"
-  puts "ips deleted"
-  puts "score deleted"
-  puts "user_watchlist_elements deleted"
-  puts "validator deleted"
+  unless Rails.env.test?
+    puts "validator_histories deleted"
+    puts "validator_block_histories deleted"
+    puts "account_authority_histories deleted"
+    puts "vote_account_histories deleted"
+    puts "vote_accounts deleted"
+    puts "commission_histories deleted"
+    puts "stake_account_histories deleted"
+    puts "stake_accounts deleted"
+    puts "ips deleted"
+    puts "score deleted"
+    puts "user_watchlist_elements deleted"
+    puts "validator deleted"
+  end
 rescue StandardError => e
   puts e.message
 end

--- a/script/one_time_scripts/remove_validator.rb
+++ b/script/one_time_scripts/remove_validator.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+# rails runner script/one_time_scripts/remove_validator.rb NETWORK ACCOUNT
+
 @network ||= ARGV[0]
 @account ||= ARGV[1]
 
-# raise "invalid network - #{network}" unless NETWORKS.include? network
+raise "invalid network - #{@network}" unless NETWORKS.include? @network
+raise "validator account is missing" if @account.blank?
 
 validator = Validator.find_by(account: @account, network: @network)
 
@@ -11,38 +14,40 @@ raise "validator not found (#{@account})" unless validator
 
 puts "found validator with id: #{validator.id}"
 
-ActiveRecord::Base.transaction do
-  validator.validator_histories.delete_all
-  validator.validator_block_histories.delete_all
+validator.validator_histories.delete_all
+puts "validator_histories deleted"
 
-  validator.vote_accounts.each do |va|
-    va.account_authority_histories.map(&:delete)
-    va.vote_account_histories.map(&:delete)
-  end
+validator.validator_block_histories.delete_all
+puts "validator_block_histories deleted"
 
-  validator.vote_accounts.delete_all
-  validator.commission_histories.delete_all
-  validator.stake_account_histories.delete_all
-  validator.stake_accounts.delete_all
-  validator.validator_ips.delete_all
-  validator.validator_score_v1&.delete
-  validator.user_watchlist_elements.delete_all
-  validator.delete
+validator.vote_accounts.each do |va|
+  va.account_authority_histories.map(&:delete)
+  puts "account_authority_histories deleted"
 
-  unless Rails.env.test?
-    puts "validator_histories deleted"
-    puts "validator_block_histories deleted"
-    puts "account_authority_histories deleted"
-    puts "vote_account_histories deleted"
-    puts "vote_accounts deleted"
-    puts "commission_histories deleted"
-    puts "stake_account_histories deleted"
-    puts "stake_accounts deleted"
-    puts "ips deleted"
-    puts "score deleted"
-    puts "user_watchlist_elements deleted"
-    puts "validator deleted"
-  end
-rescue StandardError => e
-  puts e.message
+  va.vote_account_histories.map(&:delete)
+  puts "vote_account_histories deleted"
 end
+
+validator.vote_accounts.delete_all
+puts "vote_accounts deleted"
+
+validator.commission_histories.delete_all
+puts "commission_histories deleted"
+
+validator.stake_account_histories.delete_all
+puts "stake_account_histories deleted"
+
+validator.stake_accounts.delete_all
+puts "stake_accounts deleted"
+
+validator.validator_ips.delete_all
+puts "ips deleted"
+
+validator.validator_score_v1&.delete
+puts "score deleted"
+
+validator.user_watchlist_elements.delete_all
+puts "user_watchlist_elements deleted"
+
+validator.delete
+puts "validator deleted"

--- a/script/one_time_scripts/remove_validator.rb
+++ b/script/one_time_scripts/remove_validator.rb
@@ -3,7 +3,7 @@
 network = ARGV[0]
 account = ARGV[1]
 
-raise "invalid network - #{network}" unless %w(mainnet testnet).include? network
+# raise "invalid network - #{network}" unless NETWORKS.include? network
 
 validator = Validator.find_by(account: account, network: network)
 
@@ -17,12 +17,11 @@ puts "validator_histories deleted"
 validator.validator_block_histories.delete_all
 puts "validator_block_histories deleted"
 
-vote_accounts = validator.vote_accounts
-vote_accounts.each do |va| 
-  if va.vote_account_histories.any?
-    va.vote_account_histories.map(&:delete)
-  end
+validator.vote_accounts.each do |va|
+  va.account_authority_histories.map(&:delete)
+  va.vote_account_histories.map(&:delete)
 end
+puts "account_authority_histories deleted"
 puts "vote_account_histories deleted"
 
 validator.vote_accounts.delete_all
@@ -31,17 +30,20 @@ puts "vote_accounts deleted"
 validator.commission_histories.delete_all
 puts "commission_histories deleted"
 
-StakeAccountHistory.where(validator_id: validator.id).delete_all
+validator.stake_account_histories.delete_all
 puts "stake_account_histories deleted"
 
-StakeAccount.where(validator_id: validator.id).delete_all
+validator.stake_accounts.delete_all
 puts "stake_accounts deleted"
 
-validator.validator_ips&.delete_all
+validator.validator_ips.delete_all
 puts "ips deleted"
 
 validator.validator_score_v1&.delete
 puts "score deleted"
+
+validator.user_watchlist_elements.delete_all
+puts "user_watchlist_elements deleted"
 
 validator.delete
 puts "validator deleted"

--- a/script/one_time_scripts/remove_validator.rb
+++ b/script/one_time_scripts/remove_validator.rb
@@ -11,39 +11,43 @@ raise "validator not found (#{account})" unless validator
 
 puts "found validator with id: #{validator.id}"
 
-validator.validator_histories.delete_all
-puts "validator_histories deleted"
+ActiveRecord::Base.transaction do
+  validator.validator_histories.delete_all
+  puts "validator_histories deleted"
 
-validator.validator_block_histories.delete_all
-puts "validator_block_histories deleted"
+  validator.validator_block_histories.delete_all
+  puts "validator_block_histories deleted"
 
-validator.vote_accounts.each do |va|
-  va.account_authority_histories.map(&:delete)
-  va.vote_account_histories.map(&:delete)
+  validator.vote_accounts.each do |va|
+    va.account_authority_histories.map(&:delete)
+    va.vote_account_histories.map(&:delete)
+  end
+  puts "account_authority_histories deleted"
+  puts "vote_account_histories deleted"
+
+  validator.vote_accounts.delete_all
+  puts "vote_accounts deleted"
+
+  validator.commission_histories.delete_all
+  puts "commission_histories deleted"
+
+  validator.stake_account_histories.delete_all
+  puts "stake_account_histories deleted"
+
+  validator.stake_accounts.delete_all
+  puts "stake_accounts deleted"
+
+  validator.validator_ips.delete_all
+  puts "ips deleted"
+
+  validator.validator_score_v1&.delete
+  puts "score deleted"
+
+  validator.user_watchlist_elements.delete_all
+  puts "user_watchlist_elements deleted"
+
+  validator.delete
+  puts "validator deleted"
+rescue StandardError => e
+  puts e.message
 end
-puts "account_authority_histories deleted"
-puts "vote_account_histories deleted"
-
-validator.vote_accounts.delete_all
-puts "vote_accounts deleted"
-
-validator.commission_histories.delete_all
-puts "commission_histories deleted"
-
-validator.stake_account_histories.delete_all
-puts "stake_account_histories deleted"
-
-validator.stake_accounts.delete_all
-puts "stake_accounts deleted"
-
-validator.validator_ips.delete_all
-puts "ips deleted"
-
-validator.validator_score_v1&.delete
-puts "score deleted"
-
-validator.user_watchlist_elements.delete_all
-puts "user_watchlist_elements deleted"
-
-validator.delete
-puts "validator deleted"

--- a/script/one_time_scripts/remove_validator.rb
+++ b/script/one_time_scripts/remove_validator.rb
@@ -13,40 +13,33 @@ puts "found validator with id: #{validator.id}"
 
 ActiveRecord::Base.transaction do
   validator.validator_histories.delete_all
-  puts "validator_histories deleted"
-
   validator.validator_block_histories.delete_all
-  puts "validator_block_histories deleted"
 
   validator.vote_accounts.each do |va|
     va.account_authority_histories.map(&:delete)
     va.vote_account_histories.map(&:delete)
   end
-  puts "account_authority_histories deleted"
-  puts "vote_account_histories deleted"
 
   validator.vote_accounts.delete_all
-  puts "vote_accounts deleted"
-
   validator.commission_histories.delete_all
-  puts "commission_histories deleted"
-
   validator.stake_account_histories.delete_all
-  puts "stake_account_histories deleted"
-
   validator.stake_accounts.delete_all
-  puts "stake_accounts deleted"
-
   validator.validator_ips.delete_all
-  puts "ips deleted"
-
   validator.validator_score_v1&.delete
-  puts "score deleted"
-
   validator.user_watchlist_elements.delete_all
-  puts "user_watchlist_elements deleted"
-
   validator.delete
+
+  puts "validator_histories deleted"
+  puts "validator_block_histories deleted"
+  puts "account_authority_histories deleted"
+  puts "vote_account_histories deleted"
+  puts "vote_accounts deleted"
+  puts "commission_histories deleted"
+  puts "stake_account_histories deleted"
+  puts "stake_accounts deleted"
+  puts "ips deleted"
+  puts "score deleted"
+  puts "user_watchlist_elements deleted"
   puts "validator deleted"
 rescue StandardError => e
   puts e.message

--- a/test/logic/solana_logic_test.rb
+++ b/test/logic/solana_logic_test.rb
@@ -275,11 +275,7 @@ class SolanaLogicTest < ActiveSupport::TestCase
       validators_info: @validators_info
     )
 
-    create(
-      :validator,
-      :mainnet,
-      account: '61QB1Evn9E3noQtpJm4auFYyHSXS5FPgqKtPgwJJfEQk'
-    )
+    create(:validator, :mainnet, account: '61QB1Evn9E3noQtpJm4auFYyHSXS5FPgqKtPgwJJfEQk')
 
     VCR.use_cassette('validators_info_save') do
       p = Pipeline.new(200, payload)

--- a/test/logic/solana_logic_test.rb
+++ b/test/logic/solana_logic_test.rb
@@ -269,17 +269,28 @@ class SolanaLogicTest < ActiveSupport::TestCase
     end
   end
 
-  test 'validators_info_save' do
+  test '#validators_info_save updates persisted validators' do
     #  To skip validators_info_get
     payload = @mainnet_initial_payload.merge(
       validators_info: @validators_info
+    )
+
+    create(
+      :validator,
+      :mainnet,
+      name: 'test_name',
+      keybase_id: 'test_keybase_id',
+      details: 'test_details',
+      avatar_url: 'test_avatar_url',
+      www_url: 'test_www_url',
+      account: '61QB1Evn9E3noQtpJm4auFYyHSXS5FPgqKtPgwJJfEQk'
     )
 
     VCR.use_cassette('validators_info_save') do
       p = Pipeline.new(200, payload)
                   .then(&program_accounts)
                   .then(&validators_info_save)
-      assert_equal 898, Validator.count
+      assert_equal 2, Validator.count
 
       validator = Validator.find_by(account: '61QB1Evn9E3noQtpJm4auFYyHSXS5FPgqKtPgwJJfEQk')
       assert_equal 'Meyerbro', validator.name
@@ -290,17 +301,19 @@ class SolanaLogicTest < ActiveSupport::TestCase
     end
   end
 
-  test 'validators_info_save does not save incorrect attributes' do
+  test '#validators_info_save does not save incorrect attributes' do
     #  To skip validators_info_get
     payload = @mainnet_initial_payload.merge(
       validators_info: @validators_info
     )
 
+    create(:validator, :mainnet, account: '7MTjmteQHhthwwTZhUzsc2dP4NBvGNRqj8jzdqNxHFGE', avatar_url: nil)
+
     VCR.use_cassette('validators_info_save') do
       p = Pipeline.new(200, payload)
                   .then(&program_accounts)
                   .then(&validators_info_save)
-      assert_equal 898, Validator.count
+      assert_equal 2, Validator.count
 
       validator = Validator.find_by(account: '7MTjmteQHhthwwTZhUzsc2dP4NBvGNRqj8jzdqNxHFGE')
       assert_equal 'web34ever', validator.name

--- a/test/logic/solana_logic_test.rb
+++ b/test/logic/solana_logic_test.rb
@@ -269,7 +269,7 @@ class SolanaLogicTest < ActiveSupport::TestCase
     end
   end
 
-  test '#validators_info_save updates persisted validators' do
+  test '#validators_info_save updates data for existing validators' do
     #  To skip validators_info_get
     payload = @mainnet_initial_payload.merge(
       validators_info: @validators_info
@@ -278,11 +278,6 @@ class SolanaLogicTest < ActiveSupport::TestCase
     create(
       :validator,
       :mainnet,
-      name: 'test_name',
-      keybase_id: 'test_keybase_id',
-      details: 'test_details',
-      avatar_url: 'test_avatar_url',
-      www_url: 'test_www_url',
       account: '61QB1Evn9E3noQtpJm4auFYyHSXS5FPgqKtPgwJJfEQk'
     )
 

--- a/test/scripts/remove_validator_test.rb
+++ b/test/scripts/remove_validator_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RemoveValidatorTest < ActiveSupport::TestCase
+
+  def load_script(validator)
+    @network = 'testnet'
+    @account = validator.account
+    path = Rails.root.join("script", "one_time_scripts", "remove_validator.rb").to_s
+
+    eval(File.read(path))
+  end
+
+  test "script removes validator with its all relations" do
+    validator_history = build(:validator_history)
+    validator_block_history = build(:validator_block_history)
+    account_authority_history = build(:account_authority_history)
+    vote_account_history = build(:vote_account_history)
+    vote_account = build(
+      :vote_account,
+      account_authority_histories: [account_authority_history],
+      vote_account_histories: [vote_account_history]
+    )
+    commission_history = build(:commission_history)
+    stake_account_history = build(:stake_account_history)
+    stake_account = build(:stake_account)
+    validator_ip = build(:validator_ip)
+    validator_score_v1 = build(:validator_score_v1)
+    user_watchlist_element = build(:user_watchlist_element)
+
+    validator = create(
+      :validator,
+      validator_histories: [validator_history],
+      validator_block_histories: [validator_block_history],
+      vote_accounts: [vote_account],
+      commission_histories: [commission_history],
+      stake_account_histories: [stake_account_history],
+      stake_accounts: [stake_account],
+      validator_ips: [validator_ip],
+      validator_score_v1: validator_score_v1,
+      user_watchlist_elements: [user_watchlist_element]
+    )
+
+    assert validator_history.persisted?
+    assert validator_block_history.persisted?
+    assert account_authority_history.persisted?
+    assert vote_account_history.persisted?
+    assert vote_account.persisted?
+    assert commission_history.persisted?
+    assert stake_account_history.persisted?
+    assert stake_account.persisted?
+    assert validator_ip.persisted?
+    assert validator_score_v1.persisted?
+    assert user_watchlist_element.persisted?
+
+    load_script(validator)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      validator_history.reload
+      validator_block_history.reload
+      account_authority_history.reload
+      vote_account_history.reload
+      vote_account.reload
+      commission_history.reload
+      stake_account_history.reload
+      stake_account.reload
+      validator_ip.reload
+      validator_score_v1.reload
+      user_watchlist_element.reload
+      validator.reload
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
- Modifies logic saving validator during CLI Solana request (#validators_info_save)

#### How should this be manually tested?
- `rails test`
1)
- find a validator with network 'testnet' and account '2eCPrXeWo9Cg79cK6eyJdaCoiMDKJMPq7sAhXSP3spQk'. Change its attribute (e.g. name, keybase_id, www_url) and save it.
- run `rails r script/validators_get_info.rb`
- check if the validator attributes are valid (current name is "Edgevana Validator")
2)
- run rails console and remove the validator (account: '2eCPrXeWo9Cg79cK6eyJdaCoiMDKJMPq7sAhXSP3spQk')
- run `rails r script/validators_get_info.rb` again
- in rails console try to find the validator ('2eCPrXeWo9Cg79cK6eyJdaCoiMDKJMPq7sAhXSP3spQk'). It should not exist.
3)
- create a validator with relations assigned
```
      validator_histories
      validator_block_histories
      vote_accounts
      commission_histories
      stake_account_histories
      stake_accounts
      validator_ips
      validator_score_v1
      user_watchlist_elements
```
- run `script/one_time_scripts/remove_validator.rb {validator.network} {validator.account}`
- the validator should be completely erased with its all relations.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186811096)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
