### PR TITLE
186718729 - fix paths for authorities changes in routes and sitemap

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,9 +107,10 @@ Rails.application.routes.draw do
   get 'commission-changes/(:validator_id)',
       to: 'public#commission_histories',
       as: 'commission_histories'
-  get 'authorities_changes/(:vote_account_id)',
+  get 'authorities-changes/(:vote_account_id)',
       to: 'public#authorities_changes',
       as: 'authorities_changes'
+  get 'authorities_changes/(:vote_account_id)', to: 'public#authorities_changes'
 
   get 'stake-explorer', to: 'explorer_stake_accounts#index', as: 'explorer_stake_accounts'
   get 'stake-explorer/:stake_pubkey', to: 'explorer_stake_accounts#show', as: 'explorer_stake_account'

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -61,7 +61,7 @@ SitemapGenerator::Sitemap.create do
     add "/validators?network=#{network}", changefreq: 'hourly'
     add "/trent-mode?network=#{network}", changefreq: 'daily'
     add "/commission-changes?network=#{network}", changefreq: 'hourly'
-    add "/authorities_changes?network=#{network}", changefreq: 'hourly'
+    add "/authorities-changes?network=#{network}", changefreq: 'hourly'
     add "/ping-thing?network=#{network}", changefreq: 'hourly'
   end
 


### PR DESCRIPTION
#### What's this PR do?
- fixing authorities changes paths. 

#### How should this be manually tested?
- enter authorities changes page (use footer link). It should redirect to authorities-changes path
- check behaviour when you enter /authorities_changes url. That should still be accessible and should redirect to authorities changes page.

#### What are the relevant tickets?
[- URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/186718729)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
