### PR TITLE
187184054 sort user ping stats

### DIFF
--- a/app/controllers/api/v1/ping_thing_user_stats_controller.rb
+++ b/app/controllers/api/v1/ping_thing_user_stats_controller.rb
@@ -7,7 +7,7 @@ module Api
         last_5_mins = PingThingUserStat.where(
           network: stats_params[:network],
           interval: 5
-        ).group_by(&:username)
+        ).order(:average_slot_latency).group_by(&:username)
         last_60_mins = PingThingUserStat.where(
           network: stats_params[:network],
           interval: 60

--- a/app/javascript/packs/ping_things/stats_bar.vue
+++ b/app/javascript/packs/ping_things/stats_bar.vue
@@ -24,7 +24,7 @@
         <div class="col-lg-7">
           <i class="fa-solid fa-up-long text-success me-2"></i>P90
         </div>
-        <div class="col-lg-7">
+        <div class="col-lg-7" title="Median Latency">
           <i class="fa-solid fa-clock text-success me-2"></i>Latency
         </div>
       </div>

--- a/app/javascript/packs/ping_things/user_stats.vue
+++ b/app/javascript/packs/ping_things/user_stats.vue
@@ -26,7 +26,7 @@
                   <i class="fa-solid fa-up-long text-success me-2"></i>P90
                 </th>
                 <th class="column-sm px-0">
-                  <i class="fa-solid fa-clock text-success me-2"></i>Latency
+                  <i class="fa-solid fa-clock text-success me-2"></i>Av. Latency
                 </th>
               </tr>
             </thead>

--- a/app/javascript/packs/ping_things/user_stats.vue
+++ b/app/javascript/packs/ping_things/user_stats.vue
@@ -25,8 +25,8 @@
                 <th class="column-sm px-0">
                   <i class="fa-solid fa-up-long text-success me-2"></i>P90
                 </th>
-                <th class="column-sm px-0">
-                  <i class="fa-solid fa-clock text-success me-2"></i>Av. Latency
+                <th class="column-sm px-0" title="Median Latency">
+                  <i class="fa-solid fa-clock text-success me-2"></i>Latency
                 </th>
               </tr>
             </thead>

--- a/app/models/ping_thing.rb
+++ b/app/models/ping_thing.rb
@@ -86,6 +86,8 @@ class PingThing < ApplicationRecord
   end
 
   def self.average_slot_latency
-    all.map{ |pt| pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil }.compact.average
+    all.map do |pt|
+      pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil
+    end.compact.sort.median
   end
 end

--- a/app/services/ping_thing_user_stats_service.rb
+++ b/app/services/ping_thing_user_stats_service.rb
@@ -28,9 +28,9 @@ class PingThingUserStatsService
         max: ping_times.max,
         p90: ping_times.first((ping_times.count * 0.9).to_i).last,
         num_of_records: ping_times.count,
-        average_slot_latency: user_ping_things.map do |pt| 
-                               pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil
-                             end.compact.average&.round(1),
+        average_slot_latency: user_ping_things.map do |pt|
+                                pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil
+                              end.compact.sort.median&.round(1),
         fails_count: user_ping_things.map(&:success).count(false)
       )
 

--- a/dev/create_test_ping_things.rb
+++ b/dev/create_test_ping_things.rb
@@ -27,7 +27,7 @@ counts.each do |loop|
       application: "web3",
       reported_at: rand(7.days.ago..Time.now),
       slot_sent: slot_sent,
-      slot_landed: slot_sent + rand(1..5)
+      slot_landed: slot_sent + rand(2..7)
     )
     if p.valid?
       puts p.inspect

--- a/test/models/ping_thing_recent_stat_test.rb
+++ b/test/models/ping_thing_recent_stat_test.rb
@@ -76,15 +76,14 @@ class PingThingRecentStatTest < ActiveSupport::TestCase
     # TODO
   end
 
-  test "#recalculate_stats counts average of slot latency" do
-    slot_latency = 5
-    5.times do |time|
+  test "#recalculate_stats counts median slot latency" do
+    [9,3,2,1,3,3].each do |latency|
       create(
         :ping_thing,
         :testnet,
         reported_at: rand(50.minutes.ago..Time.now),
-        slot_sent: time,
-        slot_landed: time + slot_latency
+        slot_sent: 1,
+        slot_landed: 1 + latency
       )
     end
 
@@ -93,7 +92,7 @@ class PingThingRecentStatTest < ActiveSupport::TestCase
     ping_stat.recalculate_stats
     ping_stat.reload
 
-    assert_equal slot_latency, ping_stat.average_slot_latency
+    assert_equal 3, ping_stat.average_slot_latency
   end
 
   test "#recalculate_stats counts fails count" do

--- a/test/services/ping_thing_user_stats_service_test.rb
+++ b/test/services/ping_thing_user_stats_service_test.rb
@@ -35,5 +35,6 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
     assert_equal 10, PingThingUserStat.last.num_of_records
     assert_equal @ping_things.pluck(:response_time).compact.sort.median, PingThingUserStat.last.median
     assert_equal @ping_things.pluck(:response_time).compact.sort.min, PingThingUserStat.last.min
+    assert_equal 2, PingThingUserStat.last.average_slot_latency
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Sort user ping stats by latency for 5 minutes
- Replaces latency average with median

#### How should this be manually tested?
- On staging:
  - run `RAILS_ENV=stage bundle exec rails r dev/create_test_ping_things.rb` (you can run multiple times)
  and review https://stage.validators.app/ping-thing page
- Locally:
  - run sidekiq
  - populate db with `rails r dev/create_test_ping_things.rb`  (you can run multiple times)
  - and then create stats: 
    `rails r "PingThingUserStatsWorker.perform_async('mainnet')"`
- check stats - should be sorted:
![Zrzut ekranu 2024-03-6 o 17 44 52](https://github.com/brianlong/www.validators.app/assets/32059143/ecc152a2-789f-4c95-8fa6-faa6d05cb0e3)



#### What are the relevant tickets?
- URL to the PivotalTracker ticket

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
