### PR TITLE
187257572 fix p90

### DIFF
--- a/app/models/ping_thing_recent_stat.rb
+++ b/app/models/ping_thing_recent_stat.rb
@@ -60,7 +60,7 @@ class PingThingRecentStat < ApplicationRecord
       median: ping_times.median,
       min: ping_times.min,
       max: ping_times.max,
-      p90: ping_times.first((ping_times.count * 0.9).to_i).last,
+      p90: ping_times.first((ping_times.count * 0.9).round).last,
       num_of_records: ping_times.count,
       min_slot_latency: slot_latency_stats[:min],
       average_slot_latency: slot_latency_stats[:median],

--- a/app/services/ping_thing_user_stats_service.rb
+++ b/app/services/ping_thing_user_stats_service.rb
@@ -27,7 +27,7 @@ class PingThingUserStatsService
         median: ping_times.median,
         min: ping_times.min,
         max: ping_times.max,
-        p90: ping_times.first((ping_times.count * 0.9).to_i).last,
+        p90: ping_times.first((ping_times.count * 0.9).round).last,
         num_of_records: ping_times.count,
         min_slot_latency: slot_latency_stats[:min],
         average_slot_latency: slot_latency_stats[:median],

--- a/test/models/ping_thing_recent_stat_test.rb
+++ b/test/models/ping_thing_recent_stat_test.rb
@@ -42,9 +42,10 @@ class PingThingRecentStatTest < ActiveSupport::TestCase
     ping_stat.recalculate_stats
     ping_stat.reload
 
-    assert_equal 5000, ping_stat.max
     assert_equal 1000, ping_stat.min
     assert_equal 3000, ping_stat.median
+    assert_equal 5000, ping_stat.p90
+    assert_equal 5000, ping_stat.max
     assert_equal 5, ping_stat.num_of_records
   end
 
@@ -71,12 +72,12 @@ class PingThingRecentStatTest < ActiveSupport::TestCase
     assert_equal required_keys, ping_stat.to_builder.attributes!.keys
   end
 
-  test "creating new record brodcasts message" do
+  test "creating new record broadcasts message" do
     skip
     # TODO
   end
 
-  test "#recalculate_stats counts median slot latency" do
+  test "#recalculate_stats counts slot latency stats" do
     [9,3,2,1,3,4].each do |latency|
       create(
         :ping_thing,

--- a/test/services/ping_thing_user_stats_service_test.rb
+++ b/test/services/ping_thing_user_stats_service_test.rb
@@ -26,9 +26,6 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
   end
 
   test "#call saves correct records" do
-    @ping_things.first.update(slot_landed: 124)
-    @ping_things.last(2).each { |pt| pt.update slot_landed: 126 }
-
     PingThingUserStatsService.new(network: @network, interval: 5).call
 
     assert_equal 1, PingThingUserStat.count
@@ -36,8 +33,18 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
     assert_equal @network, PingThingUserStat.last.network
     assert_equal @user.username, PingThingUserStat.last.username
     assert_equal 10, PingThingUserStat.last.num_of_records
-    assert_equal @ping_things.pluck(:response_time).compact.sort.median, PingThingUserStat.last.median
-    assert_equal @ping_things.pluck(:response_time).compact.sort.min, PingThingUserStat.last.min
+  end
+
+  test "#call calculated correct stats" do
+    @ping_things.first.update(slot_landed: 124, response_time: 10)
+    @ping_things.last(4).each { |pt| pt.update slot_landed: 126, response_time: 3 }
+
+    PingThingUserStatsService.new(network: @network, interval: 5).call
+
+    assert_equal 10, PingThingUserStat.last.num_of_records
+    assert_equal 1, PingThingUserStat.last.min
+    assert_equal 3, PingThingUserStat.last.median
+    assert_equal 3, PingThingUserStat.last.p90
     assert_equal 1, PingThingUserStat.last.min_slot_latency
     assert_equal 2, PingThingUserStat.last.average_slot_latency
     assert_equal 3, PingThingUserStat.last.p90_slot_latency


### PR DESCRIPTION
#### What's this PR do?
- Fixes p90 calculation 

#### How should this be manually tested?
- turn on sidekiq
- run `rails r dev/create_test_ping_things.rb` a couple of times 
- review /ping-thing page and confirm that min, median and p90 looks correct (both general and per user stats) and you no longer see the error described in PT
- correct output should look like below: 

<img width="1205" alt="Zrzut ekranu 2024-03-18 o 11 03 43" src="https://github.com/brianlong/www.validators.app/assets/32059143/cefd8def-a5dc-42e0-a86e-4c1ae7b3e25c">



#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187257572)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
