### PR TITLE
187277433 fix latency stats

### DIFF
--- a/app/javascript/packs/ping_things/stats_bar.vue
+++ b/app/javascript/packs/ping_things/stats_bar.vue
@@ -51,13 +51,13 @@
           </td>
 
           <td class="text-success-darker text-nowrap ps-4 ps-lg-5">
-            {{ last_5_mins["min_slot_latency"] ? last_5_mins["min_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["min_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_5_mins["min_slot_latency"] !== 'undefined') ? last_5_mins["min_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["min_slot_latency"], 'slot') : 'N / A' }}
           </td>
           <td class="text-success text-nowrap ps-0 ps-xl-1 pe-0">
-            {{ last_5_mins["average_slot_latency"] ? last_5_mins["average_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["average_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_5_mins["average_slot_latency"] !== 'undefined') ? last_5_mins["average_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["average_slot_latency"], 'slot') : 'N / A' }}
           </td>
           <td class="text-success-darker text-nowrap pe-4 pe-lg-5">
-            {{ last_5_mins["p90_slot_latency"] ? last_5_mins["p90_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["p90_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_5_mins["p90_slot_latency"] !== 'undefined') ? last_5_mins["p90_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_5_mins["p90_slot_latency"], 'slot') : 'N / A' }}
           </td>
         </tr>
         <tr>
@@ -82,13 +82,13 @@
           </td>
 
           <td class="text-success-darker text-nowrap ps-4 ps-lg-5">
-            {{ last_60_mins["min_slot_latency"] ? last_60_mins["min_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["min_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_60_mins["min_slot_latency"] !== 'undefined') ? last_60_mins["min_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["min_slot_latency"], 'slot') : 'N / A' }}
           </td>
           <td class="text-success text-nowrap ps-0 ps-xl-1 pe-0">
-            {{ last_60_mins["average_slot_latency"] ? last_60_mins["average_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["average_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_60_mins["average_slot_latency"] !== 'undefined') ? last_60_mins["average_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["average_slot_latency"], 'slot') : 'N / A' }}
           </td>
           <td class="text-success-darker text-nowrap pe-4 pe-lg-5">
-            {{ last_60_mins["p90_slot_latency"] ? last_60_mins["p90_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["p90_slot_latency"], 'slot') : 'N / A' }}
+            {{ (typeof last_60_mins["p90_slot_latency"] !== 'undefined') ? last_60_mins["p90_slot_latency"].toLocaleString('en-US', {maximumFractionDigits: 1}) + pluralize(last_60_mins["p90_slot_latency"], 'slot') : 'N / A' }}
           </td>
         </tr>
         </tbody>

--- a/app/javascript/packs/ping_things/user_stats.vue
+++ b/app/javascript/packs/ping_things/user_stats.vue
@@ -48,35 +48,35 @@
                   </span>
                 </td>
                 <td class="text-success-darker text-nowrap ps-5">
-                  {{ stats_array["5min"]["min"] ? stats_array["5min"]["min"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["5min"]["min"] ? stats_array["5min"]["min"].toLocaleString('en-US') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["min"] ? stats_array["60min"]["min"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["60min"]["min"] ? stats_array["60min"]["min"].toLocaleString('en-US') : 'N/A' }}
                 </td>
                 <td class="text-success text-nowrap px-0">
-                  {{ stats_array["5min"]["median"] ? stats_array["5min"]["median"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["5min"]["median"] ? stats_array["5min"]["median"].toLocaleString('en-US') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["median"] ? stats_array["60min"]["median"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["60min"]["median"] ? stats_array["60min"]["median"].toLocaleString('en-US') : 'N/A' }}
                 </td>
                 <td class="text-success-darker text-nowrap pe-5">
-                  {{ stats_array["5min"]["p90"] ? stats_array["5min"]["p90"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["5min"]["p90"] ? stats_array["5min"]["p90"].toLocaleString('en-US') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["p90"] ? stats_array["60min"]["p90"].toLocaleString('en-US') : 'N/A'}}
+                  {{ stats_array["60min"]["p90"] ? stats_array["60min"]["p90"].toLocaleString('en-US') : 'N/A' }}
                 </td>
 
                 <td class="text-success-darker text-nowrap ps-4 ps-lg-5">
-                  {{ stats_array["5min"]["min_slot_latency"] ? stats_array["5min"]["min_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["min_slot_latency"], 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["5min"]["min_slot_latency"] !== 'undefined') ? stats_array["5min"]["min_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["min_slot_latency"], 'slot') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["min_slot_latency"] ? stats_array["60min"]["min_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["min_slot_latency"], 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["60min"]["min_slot_latency"] !== 'undefined') ? stats_array["60min"]["min_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["min_slot_latency"], 'slot') : 'N/A' }}
                 </td>
                 <td class="text-success text-nowrap ps-0 ps-xl-1 pe-0">
-                  {{ stats_array["5min"]["average_slot_latency"] ? stats_array["5min"]["average_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["average_slot_latency"] , 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["5min"]["average_slot_latency"] !== 'undefined') ? stats_array["5min"]["average_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["average_slot_latency"] , 'slot') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["average_slot_latency"] ? stats_array["60min"]["average_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["average_slot_latency"] , 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["60min"]["average_slot_latency"] !== 'undefined') ? stats_array["60min"]["average_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["average_slot_latency"] , 'slot') : 'N/A' }}
                 </td>
                 <td class="text-success-darker text-nowrap pe-4 pe-lg-5">
-                  {{ stats_array["5min"]["p90_slot_latency"] ? stats_array["5min"]["p90_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["p90_slot_latency"], 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["5min"]["p90_slot_latency"] !== 'undefined') ? stats_array["5min"]["p90_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["5min"]["p90_slot_latency"], 'slot') : 'N/A' }}
                   <br />
-                  {{ stats_array["60min"]["p90_slot_latency"] ? stats_array["60min"]["p90_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["p90_slot_latency"], 'slot') : 'N/A'}}
+                  {{ (typeof stats_array["60min"]["p90_slot_latency"] !== 'undefined') ? stats_array["60min"]["p90_slot_latency"].toLocaleString('en-US') + pluralize(stats_array["60min"]["p90_slot_latency"], 'slot') : 'N/A' }}
                 </td>
               </tr>
             </tbody>

--- a/app/models/ping_thing.rb
+++ b/app/models/ping_thing.rb
@@ -88,7 +88,8 @@ class PingThing < ApplicationRecord
   def self.slot_latency_stats(records: nil)
     all = records || self.all
     latencies = all.map do |pt|
-      pt.slot_landed && pt.slot_sent ? pt.slot_landed - pt.slot_sent : nil
+      next unless pt.slot_landed && pt.slot_sent
+      pt.slot_landed.to_i >= pt.slot_sent.to_i ? pt.slot_landed - pt.slot_sent : nil
     end.compact.sort
     {
       min: latencies.min,

--- a/test/services/ping_thing_user_stats_service_test.rb
+++ b/test/services/ping_thing_user_stats_service_test.rb
@@ -36,7 +36,7 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
   end
 
   test "#call calculated correct stats" do
-    @ping_things.second.update(slot_landed: 123, response_time: 10)
+    @ping_things.first.update(slot_landed: 123, response_time: 10)
     @ping_things.last(4).each { |pt| pt.update slot_landed: 126, response_time: 3 }
 
     PingThingUserStatsService.new(network: @network, interval: 5).call

--- a/test/services/ping_thing_user_stats_service_test.rb
+++ b/test/services/ping_thing_user_stats_service_test.rb
@@ -36,7 +36,7 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
   end
 
   test "#call calculated correct stats" do
-    @ping_things.first.update(slot_landed: 124, response_time: 10)
+    @ping_things.second.update(slot_landed: 123, response_time: 10)
     @ping_things.last(4).each { |pt| pt.update slot_landed: 126, response_time: 3 }
 
     PingThingUserStatsService.new(network: @network, interval: 5).call
@@ -45,8 +45,20 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
     assert_equal 1, PingThingUserStat.last.min
     assert_equal 3, PingThingUserStat.last.median
     assert_equal 3, PingThingUserStat.last.p90
-    assert_equal 1, PingThingUserStat.last.min_slot_latency
+    assert_equal 0, PingThingUserStat.last.min_slot_latency
     assert_equal 2, PingThingUserStat.last.average_slot_latency
     assert_equal 3, PingThingUserStat.last.p90_slot_latency
+  end
+
+  test "#call omits incorrect latencies" do
+    @ping_things.first.update(slot_landed: 120) # incorrect latency - slot_landed smaller than slot_sent
+    @ping_things.third.update(slot_landed: nil) # incorrect slot_landed
+    @ping_things.second.update(slot_landed: 124) # correct latency 1
+
+    PingThingUserStatsService.new(network: @network, interval: 5).call
+
+    assert_equal 1, PingThingUserStat.last.min_slot_latency
+    assert_equal 2, PingThingUserStat.last.average_slot_latency
+    assert_equal 2, PingThingUserStat.last.p90_slot_latency
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Tweaks 0 latencies

#### How should this be manually tested?
- Populate db with some stats records:
```
PingThingUserStat.create average_slot_latency: 6.0, interval: 60, min: 999.0, max: 5342.0, median: 1935.0, p90: 2663.0, num_of_records: 50, network: "mainnet", user_id: User.first.id, username: User.first.username_count: 0, min_slot_latency: 0, p90_slot_latency: 16
PingThingUserStat.create average_slot_latency: 3.0, interval: 60, min: 1003.0, max: 4233.0, median: 2633.0, p90: 4233.0, num_of_records: 21, network: "mainnet", user_id: User.second.id, username: User.second.username, fails_count: 0, min_slot_latency: 0, p90_slot_latency: 6
PingThingUserStat.create average_slot_latency: 0, interval: 5, min: 1114.0, max: 4233.0, median: 1998.0, p90: 4233.0, num_of_records: 7, network: "mainnet", user_id: User.second.id, username: User.second.username, fails_count: 0, min_slot_latency: 0, p90_slot_latency: 3
```
- confirm that 0 slot latencies are displayed, and nonexistent are displayed as "N/A"

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187277433)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
