### PR TITLE
187386735-suppress-failing-users-in-pt

### DIFF
--- a/app/models/ping_thing_recent_stat.rb
+++ b/app/models/ping_thing_recent_stat.rb
@@ -52,7 +52,8 @@ class PingThingRecentStat < ApplicationRecord
       interval.minutes.ago,
       Time.now
     )
-
+    success_user_ids = ping_things.where(success: true).pluck(:user_id).uniq
+    ping_things = ping_things.where(user_id: success_user_ids)
     ping_times = ping_things.pluck(:response_time).compact.sort
     slot_latency_stats = ping_things.slot_latency_stats
 

--- a/app/services/ping_thing_user_stats_service.rb
+++ b/app/services/ping_thing_user_stats_service.rb
@@ -13,6 +13,8 @@ class PingThingUserStatsService
     gather_ping_things
     delete_old_stats
     pt_by_user.each do |user_id, user_ping_things|
+      next if user_ping_things.map(&:success).count(true) == 0
+      
       ping_times = user_ping_things.pluck(:response_time).compact.sort
       username = User.find(user_id).username
 

--- a/dev/create_test_ping_things.rb
+++ b/dev/create_test_ping_things.rb
@@ -25,7 +25,7 @@ counts.each do |loop|
       commitment_level: "confirmed",
       success: [true, false].sample,
       application: "web3",
-      reported_at: rand(7.days.ago..Time.now),
+      reported_at: rand(5.minutes.ago..Time.now),
       slot_sent: slot_sent,
       slot_landed: slot_sent + rand(1..12)
     )

--- a/test/services/ping_thing_user_stats_service_test.rb
+++ b/test/services/ping_thing_user_stats_service_test.rb
@@ -61,4 +61,11 @@ class PingThingUserStatsServiceTest < ActiveSupport::TestCase
     assert_equal 2, PingThingUserStat.last.average_slot_latency
     assert_equal 2, PingThingUserStat.last.p90_slot_latency
   end
+
+  test "#call does not save stats if no successful pings" do
+    @ping_things.each { |pt| pt.update success: false }
+
+    PingThingUserStatsService.new(network: @network, interval: 5).call
+    assert_equal 0, PingThingUserStat.count
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
- do not display stats in Ping Thing for users with 100% fail count

#### How should this be manually tested?
- run tests
- create only failed ping things for user
- run sidekiq (ping_thing_user_stats_worker)
- user data should not be displayed in a table 

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187386735)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
