### PR TITLE
187313301 process slots with missing blocks

### DIFF
--- a/app/models/validator_ip.rb
+++ b/app/models/validator_ip.rb
@@ -21,6 +21,7 @@
 #
 #  index_validator_ips_on_data_center_host_id                   (data_center_host_id)
 #  index_validator_ips_on_is_active                             (is_active)
+#  index_validator_ips_on_is_active_and_address                 (is_active,address)
 #  index_validator_ips_on_validator_id_and_version_and_address  (validator_id,version,address) UNIQUE
 #
 # Foreign Keys

--- a/app/services/blockchain/get_block_service.rb
+++ b/app/services/blockchain/get_block_service.rb
@@ -25,12 +25,12 @@ module Blockchain
           parent_slot: block["parentSlot"].to_i,
           slot_number: @slot_number
         )
-        update_slot_status
+        update_slot_status(status: "has_block")
       end
     end
 
     # available statuses: has_block, request_error, no_block, initialized
-    def update_slot_status(status: "has_block")
+    def update_slot_status(status: )
       slot = Slot.find_by(slot_number: @slot_number, network: @network)
       case status
       when "has_block"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -146,6 +146,10 @@ every 1.minute, roles: [:background] do
   runner "PingThingUserStatsWorker.perform_async('pythnet')"
 end
 
+every 30.minutes, roles: [:background] do
+  ruby_script_blockchain "check_error_slots.rb"
+end
+
 if environment == 'production'
   every 1.day, at: '1:00am', roles: [:background] do
     ruby_script 'prune_database_tables.rb'

--- a/script/blockchain/check_error_slots.rb
+++ b/script/blockchain/check_error_slots.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../config/environment', __dir__)
+
+NETWORKS.each do |network|
+  Blockchain::Slot.where(network: network, status: "response_error")
+                  .where("created_at < ?", 30.minutes.ago)
+                  .each do |slot|
+
+    Blockchain::GetBlockService.new(network, slot.slot_number).call
+  end
+end

--- a/script/blockchain/check_error_slots.rb
+++ b/script/blockchain/check_error_slots.rb
@@ -2,7 +2,7 @@
 
 require File.expand_path('../../config/environment', __dir__)
 
-DELAY = 30.minutes
+DELAY = 90.minutes
 
 NETWORKS.each do |network|
   Blockchain::Slot.where(network: network, status: "request_error")

--- a/test/services/blockchain/get_block_service_test.rb
+++ b/test/services/blockchain/get_block_service_test.rb
@@ -40,7 +40,7 @@ module Blockchain
     test "#update_slot_status updates slot status" do
       assert_equal "initialized", @slot.status
 
-      Blockchain::GetBlockService.new(@network, @slot_number, @config_urls).update_slot_status
+      Blockchain::GetBlockService.new(@network, @slot_number, @config_urls).update_slot_status(status: "has_block")
       assert_equal "has_block", @slot.reload.status
 
       Blockchain::GetBlockService.new(@network, @slot_number, @config_urls)

--- a/test/services/blockchain/get_block_service_test.rb
+++ b/test/services/blockchain/get_block_service_test.rb
@@ -44,8 +44,16 @@ module Blockchain
       assert_equal "has_block", @slot.reload.status
 
       Blockchain::GetBlockService.new(@network, @slot_number, @config_urls)
-                                 .update_slot_status(has_block: "request_error")
+                                 .update_slot_status(status: "request_error")
       assert_equal "request_error", @slot.reload.status
+    end
+
+    test "#update_slot_status updates slot status to no_block when request_error" do
+      @slot.update(status: "request_error")
+      @slot.reload
+      Blockchain::GetBlockService.new(@network, @slot_number, @config_urls)
+                                 .update_slot_status(status: "request_error")
+      assert_equal "no_block", @slot.reload.status
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- periodically check the slots with "response_error" status and make sure it has no block.

#### How should this be manually tested?
- run tests
- run `rails r daemons/blockchain/slot_subscribe_mainnet_daemon.rb` and wait until you get some slots with request error status
- run `sidekiq -q blockchain`
- run `rails r script/blockchain/check_error_slots.rb` (you may want to set delay time in the script before running)
- all of the "request_error" slots should be either "has_block" or "no block"

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187313301)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
