### PR TITLE
187568450-fix-create-png-file-test

### DIFF
--- a/test/services/update_avatar_file_service_test.rb
+++ b/test/services/update_avatar_file_service_test.rb
@@ -101,7 +101,10 @@ class UpdateAvatarFileServiceTest < ActiveSupport::TestCase
     vcr_cassette(@namespace, @cassette + "-gif") do
       assert_nothing_raised do
         @service.download_tmp_file
+        @service.process_and_save_avatar
         @service.process_image_file
+
+        @service.purge_files(false)
       end
     end
   end


### PR DESCRIPTION
#### What's this PR do?
- there's an empty .png file being created while running test - this is not a correct behaviour

#### How should this be manually tested?
- run tests
- there should not be any .png files in the root directory after tests

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187568450)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
