### PR TITLE
187641491 separate blockchanin queues

### DIFF
--- a/app/services/blockchain/get_block_service.rb
+++ b/app/services/blockchain/get_block_service.rb
@@ -19,6 +19,9 @@ module Blockchain
         params: [@slot_number, {}]
       )
       if @block[:error]
+        if @block[:error].include?("429")
+          Appsignal.send_error(StandardError.new("Rate limit exceeded"), @block.to_s)
+        end
         update_slot_status(status: "request_error")
       else
         save_block

--- a/app/services/blockchain/slot_subscribe_service.rb
+++ b/app/services/blockchain/slot_subscribe_service.rb
@@ -56,7 +56,7 @@ module Blockchain
             @logger.info("Received message: #{data["result"]["slot"]}")
 
             # delay to make sure the block is available
-            Blockchain::GetBlockWorker.set(queue: "blockchain").perform_in(20.seconds, {"network" => @network, "slot_number" => data["result"]["slot"]})
+            Blockchain::GetBlockWorker.set(queue: "blockchain_#{@network}").perform_in(20.seconds, {"network" => @network, "slot_number" => data["result"]["slot"]})
           end
         end
 

--- a/config/sidekiq_blockchain.yml.example
+++ b/config/sidekiq_blockchain.yml.example
@@ -4,6 +4,8 @@
 # :concurrency: 5
 # :timeout: 30
 development:
-  :concurrency: 4
+  :concurrency: 9
 :queues:
-  - blockchain
+  - [blockchain_mainnet, 1]
+  - [blockchain_testnet, 1]
+  - [blockchain_pythnet, 1]

--- a/script/blockchain/check_error_slots.rb
+++ b/script/blockchain/check_error_slots.rb
@@ -9,6 +9,6 @@ networks.each do |network|
   Blockchain::Slot.where(network: network, status: "request_error")
                   .where("created_at < ?", DELAY.ago)
                   .each do |slot|
-    Blockchain::GetBlockWorker.set(queue: "blockchain").perform_async({"network" => network, "slot_number" => slot.slot_number})
+    Blockchain::GetBlockWorker.set(queue: "blockchain_#{network}").perform_async({"network" => network, "slot_number" => slot.slot_number})
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- create a separate blockchain for each network
- handle 429 error from rpcpool

#### How should this be manually tested?
- change your sidekiq_blockchain.yml file according to the example
- run sidekiq
- run `sidekiq -C config/sidekiq_blockchain.yml`
- run slot_subscribe daemons
- run script/blockchain/check_error_slots.rb

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/187641491)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
