### PR TITLE
188054694-fixConnectionNotEstablished-error-handling

### DIFF
--- a/app/services/gatherers/vote_account_details_service.rb
+++ b/app/services/gatherers/vote_account_details_service.rb
@@ -38,10 +38,13 @@ module Gatherers
       @retry_count += 1
       retry if @retry_count < 3
     rescue StandardError => e
-      Appsignal.send_error(e)
       sleep 5
       @retry_count += 1
-      retry if @retry_count < 3
+      if @retry_count < 3
+        retry
+      else
+        raise e
+      end
     end
 
     private

--- a/daemons/gather_vote_account_details_daemon.rb
+++ b/daemons/gather_vote_account_details_daemon.rb
@@ -18,6 +18,9 @@ begin
     else
       sleep(10.seconds)
     end
+  rescue ActiveRecord::ConnectionNotEstablished => e
+    Appsignal.send_error(e)
+    break
   end
 rescue StandardError => e
   puts "#{e.class}\n#{e.message}"


### PR DESCRIPTION
#### What's this PR do?
- fix ConnectionNotEstablished error handling for vote accounts daemon

#### How should this be manually tested?
- run `rails r daemons/gather_vote_account_details_daemon.rb`
- turn off mysql server
- it should retry 3 times and shut down afterwards

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/188054694)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
