### PR TITLE
remove 'true' flash message

### DIFF
--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,8 +1,8 @@
 <div>
   <% flash.each do |type, msg| %>
-    <% next if flash_message_is_cookie_info(msg) %>
+    <% next if flash_message_is_cookie_info(msg) || type == "timedout" %>
     <div class="alert <%= bootstrap_class_for_flash(type) %> alert-dismissible fade show" role="alert">
-      <%= msg.to_s.html_safe %>
+      <%= msg.to_s.html_safe%>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -2,7 +2,7 @@
   <% flash.each do |type, msg| %>
     <% next if flash_message_is_cookie_info(msg) || type == "timedout" %>
     <div class="alert <%= bootstrap_class_for_flash(type) %> alert-dismissible fade show" role="alert">
-      <%= msg.to_s.html_safe%>
+      <%= msg.to_s.html_safe %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>


### PR DESCRIPTION
#### What's this PR do?
- there's a flash with "true" after user session expires - we don't need that
- 
#### How should this be manually tested?
- change `config.timeout_in` value in config/initializers/devise.rb to e.g. 1.minute
- log in
- after your session expires refresh the page
- there should be only one flash message about session expiration (no other flash with "true")

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/188062372)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
