### PR TITLE
188526101-mysql-error-handling-for-front-stats

### DIFF
--- a/daemons/front_stats_update_daemon.rb
+++ b/daemons/front_stats_update_daemon.rb
@@ -67,6 +67,10 @@ loop do
     ActionCable.server.broadcast("front_stats_channel", parsed_response)
 
     sleep(sleep_time)
+  rescue ActiveRecord::ConnectionNotEstablished => e
+    Appsignal.send_error(e)
+    puts "#{e.class}\n#{e.message}"
+    exit(500)
   rescue => e
     puts e
     puts e.backtrace


### PR DESCRIPTION
#### What's this PR do?
- rescue connection not established in front stats update daemon

#### How should this be manually tested?
- run `rails r daemons/front_stats_update_daemon.rb`
- stop mysql server
- daemon should exit

#### What are the relevant tickets?
- [URL to the PivotalTracker ticket](https://www.pivotaltracker.com/story/show/188526101)

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
