### PR TITLE
Fix software client mapping

### DIFF
--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -240,10 +240,11 @@ module SolanaLogic
           end
 
           client == 'Unknown(4)' ? client = 'AgavePaladin' : client
-          client == 'Unknown(5)' ? client = 'AgaveBam' : client
-          client == 'Unknown(6)' ? client = 'Firedancer' : client
+          client == 'Unknown(5)' ? client = 'Firedancer' : client
+          client == 'Unknown(6)' ? client = 'AgaveBam' : client
           client == 'Unknown(8)' ? client = 'Rakurai' : client
           client == 'Unknown(10)' ? client = 'HarmonicAgave' : client
+          client == 'Unknown(11)' ? client = 'HarmonicFrankendancer' : client
 
           client_id = if client&.match(/^Unknown/)
                         client&.gsub('Unknown', '')&.gsub('(', '')&.gsub(')', '')&.to_i

--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -227,13 +227,17 @@ module SolanaLogic
           'HarmonicFrankendancer': 11
         }
 
-        if hash['clientId']
-          # if client ID present, map client name
-          client_id = hash['clientId'].to_i
+        if hash['clientId'] && hash['clientId'].is_a?(Integer)
+          # if client ID is number, map client name
+          client_id = hash['clientId']
           client = (clients_mapping.key(client_id) || 'Unknown').to_s
         else
-          # if client name present, map client ID
-          client = hash['version']&.match(/client:[a-zA-Z0-9()]+/)&.to_s&.gsub('client:', '')&.sub(')', '')
+          # if client ID is string or client name present, map client ID
+          if hash['clientId'].is_a?(String)
+            client = hash['clientId']
+          else
+            client = hash['version']&.match(/client:[a-zA-Z0-9()]+/)&.to_s&.gsub('client:', '')&.sub(')', '')
+          end
           client == 'Unknown(4)' ? client = 'AgavePaladin' : client
           client_id = if client&.match(/^Unknown/)
                         client&.gsub('Unknown', '')&.gsub('(', '')&.gsub(')', '')&.to_i

--- a/app/logic/solana_logic.rb
+++ b/app/logic/solana_logic.rb
@@ -238,7 +238,13 @@ module SolanaLogic
           else
             client = hash['version']&.match(/client:[a-zA-Z0-9()]+/)&.to_s&.gsub('client:', '')&.sub(')', '')
           end
+
           client == 'Unknown(4)' ? client = 'AgavePaladin' : client
+          client == 'Unknown(5)' ? client = 'AgaveBam' : client
+          client == 'Unknown(6)' ? client = 'Firedancer' : client
+          client == 'Unknown(8)' ? client = 'Rakurai' : client
+          client == 'Unknown(10)' ? client = 'HarmonicAgave' : client
+
           client_id = if client&.match(/^Unknown/)
                         client&.gsub('Unknown', '')&.gsub('(', '')&.gsub(')', '')&.to_i
                       else


### PR DESCRIPTION
#### What's this PR do?
- Fixes software client mapping in case software name is given as "clientId" in RPC response

#### How should this be manually tested?
- Run gather_rpc_mainnet_daemon.rb and validator_score_mainnet_v1_daemon.rb, turn off after a while
- Check software_client_id and software_client values in ValidatorScoreV1

#### Task completed checklist:
- [] Is there appropriate test coverage?
- [] Did I take into consideration possible security vulnerabilities?
- [] Are the controllers secure?
- [] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
